### PR TITLE
Fix/boxconfig builder padding

### DIFF
--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/BoxConfiguration.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/BoxConfiguration.java
@@ -78,13 +78,14 @@ public class BoxConfiguration {
         return this.parser;
     }
 
+    @Override
     public String toString() {
         return "BoxConfiguration[" +
-                "centerPadding=" + centerPadding +
-                ", textAlign=" + textAlign +
+                "textAlign=" + textAlign +
                 ", parser=" + parser +
                 ", borderStyle=" + borderStyle +
                 ", autoSize=" + autoSize +
+                ", padding=" + padding +
                 ']';
     }
 
@@ -93,12 +94,12 @@ public class BoxConfiguration {
         if (object == null || getClass() != object.getClass()) return false;
 
         BoxConfiguration that = (BoxConfiguration) object;
-        return centerPadding == that.centerPadding && autoSize == that.autoSize && textAlign == that.textAlign && parser.equals(that.parser) && Objects.equals(borderStyle, that.borderStyle);
+        return centerPadding == that.centerPadding && autoSize == that.autoSize && textAlign == that.textAlign && parser.equals(that.parser) && Objects.equals(borderStyle, that.borderStyle) && padding == that.padding;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(centerPadding, autoSize, textAlign, parser, borderStyle);
+        return Objects.hash(padding, autoSize, textAlign, parser, borderStyle);
     }
 
     public static class BoxConfigurationBuilder {


### PR DESCRIPTION
Closes: #27 
## Added
- `BoxConfigurationBuilder` now returns its reference when `padding()` is called
- Update `equals()`, `hashcode()`, `toString()` contracts to include padding