### PR TITLE
Unify auto-sizing behaviour between Box and Frame #24

### DIFF
--- a/Changelogs.md
+++ b/Changelogs.md
@@ -94,5 +94,16 @@ Changes to the SPI module in this release.
 
 ## clique-spi [1.0.4] - 2026-03-24
 - Updated `author()` and `url()` metadata in CliqueTheme interface to be optional in the interface (i.e it is no longer mandatory for those metadata to be filled). Instead they default to an EMPTY string
- 
+
+
+# Changelog
+
+## Clique [3.1.3] - 2026-03-26
+### Changed
+- `Box` auto-sizing is now implicit when no dimensions are provided, matching `Frame`'s behaviour
+
+### Deprecated
+- `BoxConfigurationBuilder#autoSize()`, `BoxConfiguration#getAutoSize()` — auto-sizing is now the default; configure dimensions directly on the builder
+- `Box#noDimensions()` in favor of `Box#autoSize()` on the builder
+
 Report issues at: https://github.com/kusoroadeolu/Clique/issues**

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/boxes/AbstractBox.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/boxes/AbstractBox.java
@@ -12,8 +12,8 @@ import java.util.Objects;
 import static io.github.kusoroadeolu.clique.core.utils.Constants.ZERO;
 
 public abstract class AbstractBox implements Box {
-    int width;
-    int height;
+    int width = 0;
+    int height = 0; //If width and height == 0
     String boxContent;
     String cachedString = null;
     WidthAwareList cells;
@@ -25,7 +25,7 @@ public abstract class AbstractBox implements Box {
     private static final String TEXT_ALIGN_NOT_NULL = "Text align cannot be null";
 
 
-    public AbstractBox() {
+    AbstractBox() {
         this(ZERO, ZERO);
     }
 
@@ -71,7 +71,7 @@ public abstract class AbstractBox implements Box {
         var config = this.boxConfiguration;
         int padding = config.getPadding();
 
-        if (config.getAutoSize()) {
+        if (config.getAutoSize() || (width == 0 && height == 0)) { //if width and height == 0 autosize() was called
             this.width = cells.longest() + (padding * 2);
             this.height = cells.size(); //Taking into account the top and bottom border
         } else {
@@ -84,6 +84,7 @@ public abstract class AbstractBox implements Box {
         }
     }
 
+    //Splits the box content per newline, maps each chunk to a cell and encompasses them in a list
     WidthAwareList resolveLines(){
         var parser = boxConfiguration.getParser();
         var cellList = boxContent.lines()
@@ -92,7 +93,6 @@ public abstract class AbstractBox implements Box {
         return new WidthAwareList(cellList);
     }
 
-    //Splits the box content per newline, maps each chunk to a cell and encompasses them in a list
 
 
     @Override
@@ -118,7 +118,7 @@ public abstract class AbstractBox implements Box {
         public Box withDimensions(int width, int height) {
             if (width <= 0 || height <= 0) {
                 throw new IllegalArgumentException(
-                        "Width and height must be greater than 0. To skip dimensions, enable autoSize() in BoxConfiguration and call noDimensions()."
+                        "Width and height must be greater than 0. To skip dimensions, use the autosize() method instead."
                 );
             }
 
@@ -127,11 +127,15 @@ public abstract class AbstractBox implements Box {
             return box;
         }
 
+        /**
+         * @deprecated in favor of {@link BoxDimensionBuilder#autosize()} method . This will be removed in a future release
+         * */
+        @Deprecated(since = "3.1.3", forRemoval = true)
         public Box noDimensions() {
-            if (!this.box.boxConfiguration.getAutoSize())
-                throw new IllegalStateException(
-                        "noDimensions() requires autoSize to be enabled in BoxConfiguration"
-                );
+           return autosize();
+        }
+
+        public Box autosize(){
             this.box.width = 0;
             this.box.height = 0;
             return this.box;

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/BoxConfiguration.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/BoxConfiguration.java
@@ -1,6 +1,7 @@
 package io.github.kusoroadeolu.clique.config;
 
 
+import io.github.kusoroadeolu.clique.boxes.AbstractBox;
 import io.github.kusoroadeolu.clique.parser.AnsiStringParser;
 
 import java.util.Objects;
@@ -55,13 +56,17 @@ public class BoxConfiguration {
     }
 
     /**
-     * @deprecated As of 3.1, due to confusing/incorrect semantics. This will be removed in a future release.
+     * @deprecated As of 3.1.0, due to confusing/incorrect semantics. This will be removed in a future release.
      */
     @Deprecated(forRemoval = true, since = "3.1")
     public int getCenterPadding() {
         return this.centerPadding;
     }
 
+    /**
+     * @deprecated As of 3.1.3, in favor of {@link AbstractBox.BoxDimensionBuilder#autosize()}. This will be removed in a future release.
+     */
+    @Deprecated(forRemoval = true, since = "3.1.3")
     public boolean getAutoSize() {
         return this.autoSize;
     }
@@ -126,6 +131,10 @@ public class BoxConfiguration {
             return this;
         }
 
+        /**
+         * @deprecated As of 3.1.3, in favor of {@link AbstractBox.BoxDimensionBuilder#autosize()}. This will be removed in a future release.
+         */
+        @Deprecated(since = "3.1.3", forRemoval = true)
         public BoxConfigurationBuilder autoSize() {
             this.autoSize = true;
             return this;

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/boxes/BoxTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/boxes/BoxTest.java
@@ -63,17 +63,12 @@ class BoxTest {
                         .withDimensions(10, 0));
     }
 
-    @Test
-    void assertThrows_onNoDimensions_ifAutoSizeConfigIsAbsent(){
-        assertThrows(IllegalStateException.class,
-                () -> Clique.box()
-                        .noDimensions());
-    }
 
+    //Simple regression test
     @Test
-    void assertDoesNotThrow_onNoDimensions_ifAutoSizeConfigIsAbsent(){
-        assertDoesNotThrow(() -> Clique.box(BoxConfiguration.builder().autoSize().build())
-                        .noDimensions());
+    void assertDoesNotThrow_onAutoSize(){
+        assertDoesNotThrow(() -> Clique.box()
+                        .autosize());
     }
 
     @Test
@@ -91,9 +86,8 @@ class BoxTest {
 
     @Test
     void borderStyleConfig_shouldApplyGivenChanges(){
-        var autosize = BoxConfiguration.builder().autoSize().build();
-        var box = Clique.box(BoxType.DEFAULT, autosize)
-                .noDimensions()
+        var box = Clique.box(BoxType.DEFAULT)
+                .autosize()
                 .content("Hello"); //ASCII //ASCII Box
         List<String> lines = box.get().lines().toList();
         var line1 = lines.getFirst();
@@ -108,11 +102,10 @@ class BoxTest {
                 .horizontalChar('~')
                 .verticalChar('/')
                 .build();
-        var config = BoxConfiguration.builder().autoSize().borderStyle(style).build();
 
 
-        var frame2 = Clique.box(BoxType.DEFAULT, config)
-                .noDimensions()
+        var frame2 = Clique.box(BoxType.DEFAULT, style)
+                .autosize()
                 .content("Hello"); //ASCII
         List<String> lines2 = frame2.get().lines().toList();
         var lines2_1 = lines2.getFirst();
@@ -131,12 +124,11 @@ class BoxTest {
 
         var config = BoxConfiguration
                 .builder()
-                .autoSize()
                 .borderStyle(style)
                 .build();
 
         var frame2 = Clique.box(BoxType.DEFAULT, config)
-                .noDimensions()
+                .autosize()
                 .content("Hello"); //ASCII
         List<String> lines2 = frame2.get().lines().toList();
         var lines2_1 = lines2.getFirst();

--- a/docs/boxes.md
+++ b/docs/boxes.md
@@ -29,9 +29,17 @@ box.render(); // Print the box to terminal
 - **Width** - The horizontal size of the box (in characters)
 - **Height** - The vertical size of the box (in lines)
 ```java
-Clique.box(BoxType.DEFAULT)
+Clique.box()
     .withDimensions(50, 5)  // Width, height
     .content("A wider, shorter box")
+    .render();
+```
+
+**AutoSized boxes**
+```java
+Clique.box()
+    .autosize() //Autosizes the box
+    .content("An autosized box")
     .render();
 ```
 
@@ -66,7 +74,7 @@ Clique.box(BoxType.CLASSIC)
 Boxes support a range of text alignments, with the default being centered:
 ```java
 Clique.box(BoxType.CLASSIC)
-    .withDimensions(40, 10)
+    .autosize()
     .content(
         """
             [green, bold]Success![/]
@@ -121,7 +129,7 @@ BoxConfiguration config = builder.build();
 
 #### Auto Size
 
-Let the box automatically resize to fit its content:
+Let the box automatically resize to fit its content. This is deprecated in favor of `Clique.box#autosize()`
 ```java
 BoxConfiguration config = BoxConfiguration.builder()
     .autoSize()

--- a/docs/clique.md
+++ b/docs/clique.md
@@ -57,7 +57,7 @@ Clique.table()
 - `table(TableType, BorderSpec)` - Create table with specific type and uniform border styling
 
 **Available Types:**
-`DEFAULT`, `COMPACT`/`MINIMAL`, `BOX_DRAW`, `ROUNDED_BOX_DRAW`, `MARKDOWN`
+`DEFAULT`, `COMPACT`, `BOX_DRAW`, `ROUNDED_BOX_DRAW`, `MARKDOWN`
 
 > **Note:** `customizableTable()` and its overloads are deprecated as of 3.1. Use the `table()` methods above instead. They will be removed in a future release.
 
@@ -67,7 +67,7 @@ Single-cell containers for displaying text with borders.
 
 ```java
 Clique.box()
-    .withDimensions(40, 10)
+    .autosize()
     .content("Your message here")
     .render();
 ```

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -109,7 +109,7 @@ Clique.table(TableType.DEFAULT)
 
 // Boxes with markup
 Clique.box(BoxType.ROUNDED)
-    .withDimensions(10, 10)
+    .autosize()
     .content("[bold, blue]This is a configured box[/]")
     .render();
 


### PR DESCRIPTION
Closes: #24

## Added 
- `autosize()` method to BoxDimensionBuilder 
-  `Box#noDimensions()` in favor of `Box#autoSize()`. No longer throws, delegates to `autoSize()` internally
- Updated stale docs to reflect the new changes

### Deprecated
- `BoxConfigurationBuilder#autoSize()`, `BoxConfiguration#getAutoSize()`, auto-sizing is now the default; configure dimensions directly on the builder
- `Box#noDimensions()` in favor of `Box#autoSize()` on the builder