### PR TITLE
Fix/strict parsing

### DIFF
--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/MarkupPreProcessor.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/MarkupPreProcessor.java
@@ -1,4 +1,21 @@
 package io.github.kusoroadeolu.clique.core.parser;
 
+import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
+
+@InternalApi(since = "3.1.3")
 public class MarkupPreProcessor {
+    private static final String ESCAPE_SEQUENCE = "\\[";
+    private static final String ESCAPE_PLACEHOLDER = "[\u0000ESC_BRACKET\u0000";
+
+    public String preProcess(String input) {
+        if (input == null || input.isEmpty()) return input;
+        return input.replace(ESCAPE_SEQUENCE, ESCAPE_PLACEHOLDER);
+    }
+
+    public String postProcess(String output) {
+        if (output == null || output.isEmpty()) return output;
+        return output.replace(ESCAPE_PLACEHOLDER, "[");
+    }
+
+
 }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/MarkupPreProcessor.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/MarkupPreProcessor.java
@@ -1,0 +1,4 @@
+package io.github.kusoroadeolu.clique.core.parser;
+
+public class MarkupPreProcessor {
+}

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/MarkupPreProcessor.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/MarkupPreProcessor.java
@@ -4,18 +4,37 @@ import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
 
 @InternalApi(since = "3.1.3")
 public class MarkupPreProcessor {
-    private static final String ESCAPE_SEQUENCE = "\\[";
-    private static final String ESCAPE_PLACEHOLDER = "[\u0000ESC_BRACKET\u0000";
+    private static final char ESCAPE_CHAR = '\\';
+    private static final char BRACKET = '[';
+    private static final char PLACEHOLDER = '\uE000';
 
     public String preProcess(String input) {
         if (input == null || input.isEmpty()) return input;
-        return input.replace(ESCAPE_SEQUENCE, ESCAPE_PLACEHOLDER);
+
+        int idx = input.indexOf(ESCAPE_CHAR);
+        final int len = input.length();
+        if (idx < 0 || idx == len - 1) return input;
+
+        final var sb = new StringBuilder();
+
+        for (int i = 0; i < len; i++) {
+            final char c = input.charAt(i);
+            int nextIdx = i + 1;
+            if (c == ESCAPE_CHAR && nextIdx < len && input.charAt(nextIdx) == BRACKET) {
+                sb.append(PLACEHOLDER);
+                i++;
+            } else sb.append(c);
+
+        }
+
+        return sb.toString();
     }
 
     public String postProcess(String output) {
         if (output == null || output.isEmpty()) return output;
-        return output.replace(ESCAPE_PLACEHOLDER, "[");
+
+        if (output.indexOf(PLACEHOLDER) < 0) return output;
+
+        return output.replace(PLACEHOLDER, BRACKET);
     }
-
-
 }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/ParseResult.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/ParseResult.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 @InternalApi(since = "3.1.3")
 public record ParseResult(
-        List<ParserToken> tokens,
+        List<ParseToken> tokens,
         List<String> extractedFormTags
 ) {
     public boolean isPresent(){

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/ParseResult.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/ParseResult.java
@@ -10,6 +10,6 @@ public record ParseResult(
         List<String> extractedFormTags
 ) {
     public boolean isPresent(){
-        return !tokens.isEmpty() && !extractedFormTags.isEmpty();
+        return !tokens.isEmpty();
     }
 }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/ParseToken.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/ParseToken.java
@@ -10,6 +10,6 @@ import java.util.List;
 public record ParseToken(
         int start,
         int end,
-        List<AnsiCode> validStyles
+        List<AnsiCode> styles
 ) {
 }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/ParseToken.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/ParseToken.java
@@ -7,7 +7,7 @@ import io.github.kusoroadeolu.clique.spi.AnsiCode;
 import java.util.List;
 
 @InternalApi(since = "3.1.3")
-public record ParserToken(
+public record ParseToken(
         int start,
         int end,
         List<AnsiCode> validStyles

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/StyleApplicator.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/StyleApplicator.java
@@ -13,7 +13,7 @@ import java.util.List;
 public final class StyleApplicator {
 
     //Restyle the extracted string with the given colors
-    public String restyleString(List<ParserToken> tokens, String extractedString, boolean enableAutoCloseTags) {
+    public String restyleString(List<ParseToken> tokens, String extractedString, boolean enableAutoCloseTags) {
         final StringBuilder sb = new StringBuilder();
         final StyleBuilder stb = Clique.styleBuilder();
         String val;
@@ -30,21 +30,17 @@ public final class StyleApplicator {
 
         try {
             for (int i = 0; i < size; i++) {
-                final ParserToken curr = tokens.get(i);
-                final ParserToken next = i != (size - 1) ? tokens.get(i + 1) :
-                        new ParserToken(extractedString.length(), 0, null); //if we're at the end of the loop, we apply the current style to the rem of the string
+                final ParseToken curr = tokens.get(i);
+                final ParseToken next = i != (size - 1) ? tokens.get(i + 1) :
+                        new ParseToken(extractedString.length(), 0, null); //if we're at the end of the loop, we apply the current style to the rem of the string
 
                 final AnsiCode[] codes = curr.validStyles().toArray(AnsiCode[]::new);
                 final int start = curr.end() + 1;
                 final int end = next.start();
                 val = extractedString.substring(start, end);
 
-                if (enableAutoCloseTags) {
-                    sb.append(stb.formatAndReset(val, codes));
-                    continue;
-                }
-
-                sb.append(stb.format(val, codes));
+                if (enableAutoCloseTags) sb.append(stb.formatAndReset(val, codes));
+                else sb.append(stb.format(val, codes));
             }
         } catch (StringIndexOutOfBoundsException e) {
             throw new ParseProblemException("Failed to parse string. This often happens when style tags have nested brackets like '[[red]]'.", e);

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/StyleApplicator.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/StyleApplicator.java
@@ -3,7 +3,6 @@ package io.github.kusoroadeolu.clique.core.parser;
 
 import io.github.kusoroadeolu.clique.Clique;
 import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
-import io.github.kusoroadeolu.clique.core.exceptions.ParseProblemException;
 import io.github.kusoroadeolu.clique.spi.AnsiCode;
 import io.github.kusoroadeolu.clique.style.StyleBuilder;
 
@@ -27,14 +26,12 @@ public final class StyleApplicator {
         if (tokens.getFirst().start() != 0) {
             sb.append(extractedString, 0, tokens.getFirst().start());
         }
-
-        try {
-            for (int i = 0; i < size; i++) {
+         for (int i = 0; i < size; i++) {
                 final ParseToken curr = tokens.get(i);
                 final ParseToken next = i != (size - 1) ? tokens.get(i + 1) :
                         new ParseToken(extractedString.length(), 0, null); //if we're at the end of the loop, we apply the current style to the rem of the string
 
-                final AnsiCode[] codes = curr.validStyles().toArray(AnsiCode[]::new);
+                final AnsiCode[] codes = curr.styles().toArray(AnsiCode[]::new);
                 final int start = curr.end() + 1;
                 final int end = next.start();
                 val = extractedString.substring(start, end);
@@ -42,9 +39,6 @@ public final class StyleApplicator {
                 if (enableAutoCloseTags) sb.append(stb.formatAndReset(val, codes));
                 else sb.append(stb.format(val, codes));
             }
-        } catch (StringIndexOutOfBoundsException e) {
-            throw new ParseProblemException("Failed to parse string. This often happens when style tags have nested brackets like '[[red]]'.", e);
-        }
 
         return sb.toString();
     }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/TokenExtractor.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/TokenExtractor.java
@@ -43,7 +43,7 @@ public final class TokenExtractor {
 
             if (c == FORM_START) { //This will always switch the form start, if it finds another [ after this
                 //If we're still tracking, this means we have nested tag, just skip it
-                fcDepth = 0; //Next form start, reset fc depth
+                fcDepth = 0; //Next form start, reset fc depth. Basically means we had something like this ]some_string[
                 idx = i;
                 ++fsDepth;
             }
@@ -59,7 +59,8 @@ public final class TokenExtractor {
                         formTags.add(fullTag);
                     }
                 }
-                --fsDepth;
+
+                fsDepth = Math.max(0, --fsDepth);
             }
         }
 

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/TokenExtractor.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/TokenExtractor.java
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
 public final class TokenExtractor {
     private static final char FORM_START = '[';
     private static final char FORM_CLOSE = ']';
+    private static final String MARKUP_ESCAPE = "[/]";
 
     /**
      * Extracts valid tokens and form tags from the given string
@@ -28,34 +29,38 @@ public final class TokenExtractor {
      *
      */
     public ParseResult getParseResult(String stringToParse, String delimiter, boolean enableStrictParsing) {
-        final List<ParserToken> tokens = new ArrayList<>(); //List to store the tokens gotten from this string
+        final List<ParseToken> tokens = new ArrayList<>(); //List to store the tokens gotten from this string
         final List<String> formTags = new ArrayList<>(); //Tracks the form tags extracted from this string
 
         if (stringToParse == null || stringToParse.isEmpty()) return new ParseResult(List.of(), List.of());
 
         final int len = stringToParse.length();
-        int idx = 0; //The start of the tag
-        boolean isTracking = false; //Tracking boolean to keep track of if we're currently tracking a style or not
+        int tagStart = 0; //The start of the tag
+        boolean inMarkupTag = false; //Tracking boolean to keep track of if we're currently tracking a style or not
 
         for (int i = 0; i < len; i++) {
             final char c = stringToParse.charAt(i);
             if (c == FORM_START) { //This will always switch the form start, if it finds another [ after this
-                if (isTracking && enableStrictParsing) { //If we're still tracking, this means we have nested form start
-                    throw new ParseProblemException("Nested tag detected at index: " + i);
+                if (inMarkupTag && enableStrictParsing) { //If we're still tracking, this means we have nested form start
+                    int j = i + 3;
+                    if (j < len){
+                        String shorthand = stringToParse.substring(i,  i + 3);
+                        if (!shorthand.equals(MARKUP_ESCAPE)){
+                            throw new ParseProblemException("Nested tag detected at index: " + i);
+                        }
+                    }
                 }
-
-
-                idx = i;
-                isTracking = true;
+                tagStart = i;
+                inMarkupTag = true;
             }
 
-            if (c == FORM_CLOSE && isTracking) { //Only parse the string if we're still tracking the valid tag
-                final String fullTag = stringToParse.substring(idx, i + 1); //Parse the extracted string and skip the braces
-                final List<AnsiCode> validStyles = this.getValidStyles(fullTag, delimiter, enableStrictParsing);
+            if (c == FORM_CLOSE && inMarkupTag) { //Only parse the string if we're still tracking the valid tag
+                final String markupTag = stringToParse.substring(tagStart, i + 1); //Parse the extracted string and skip the braces
+                final List<AnsiCode> validStyles = this.getValidStyles(markupTag, delimiter, enableStrictParsing);
                 if (validStyles != null && !validStyles.isEmpty()) {
-                    tokens.add(new ParserToken(idx, i, validStyles));
-                    formTags.add(fullTag);
-                    isTracking = false;
+                    tokens.add(new ParseToken(tagStart, i, validStyles));
+                    formTags.add(markupTag);
+                    inMarkupTag = false;
                 }
             }
         }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/TokenExtractor.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/TokenExtractor.java
@@ -30,6 +30,7 @@ public final class TokenExtractor {
     public ParseResult getParseResult(String stringToParse, String delimiter, boolean enableStrictParsing) {
         final List<ParseToken> tokens = new ArrayList<>(); //List to store the tokens gotten from this string
         final List<String> formTags = new ArrayList<>(); //Tracks the form tags extracted from this string
+        final String delimiterPattern = Pattern.quote(delimiter);
 
         if (stringToParse == null || stringToParse.isEmpty()) return new ParseResult(List.of(), List.of());
 
@@ -53,7 +54,7 @@ public final class TokenExtractor {
 
                 if (fsDepth == 1 && fcDepth == 1){ //Only if we dont have nested tags, with both open and closed tags
                     final String fullTag = stringToParse.substring(idx, i + 1); //Parse the extracted string and skip the braces
-                    final List<AnsiCode> validStyles = this.getValidStyles(fullTag, delimiter, enableStrictParsing);
+                    final List<AnsiCode> validStyles = this.getValidStyles(fullTag, delimiterPattern, enableStrictParsing);
                     if (!validStyles.isEmpty()) {
                         tokens.add(new ParseToken(idx, i, validStyles));
                         formTags.add(fullTag);
@@ -77,11 +78,11 @@ public final class TokenExtractor {
 
     //Check if there are valid styles in the extracted string
     //ESP -> Enable strict parsing
-    private List<AnsiCode> getValidStyles(String extractedStr, String delimiter, boolean esp) {
+    private List<AnsiCode> getValidStyles(String extractedStr, String delimiterPattern, boolean esp) {
         if (extractedStr.length() <= 2) return List.of();  //Check if the extracted string is just empty braces, or a malformed tag
         extractedStr = this.cleanString(extractedStr); //Clean the string
 
-        final String[] styles = extractedStr.split(Pattern.quote(delimiter));
+        final String[] styles = extractedStr.split(delimiterPattern);
         final List<AnsiCode> validStyles = new ArrayList<>();
         for (String s : styles) {
             s = s.toLowerCase(Locale.ROOT).trim();

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/TokenExtractor.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/TokenExtractor.java
@@ -19,7 +19,6 @@ import java.util.regex.Pattern;
 public final class TokenExtractor {
     private static final char FORM_START = '[';
     private static final char FORM_CLOSE = ']';
-    private static final String MARKUP_ESCAPE = "[/]";
 
     /**
      * Extracts valid tokens and form tags from the given string
@@ -35,44 +34,50 @@ public final class TokenExtractor {
         if (stringToParse == null || stringToParse.isEmpty()) return new ParseResult(List.of(), List.of());
 
         final int len = stringToParse.length();
-        int tagStart = 0; //The start of the tag
-        boolean inMarkupTag = false; //Tracking boolean to keep track of if we're currently tracking a style or not
+        int idx = 0; //The start of the tag
+        int fsDepth = 0; //Tracking boolean to keep track of the number of form starts we've seen
+        int fcDepth = 0;
 
         for (int i = 0; i < len; i++) {
             final char c = stringToParse.charAt(i);
+
             if (c == FORM_START) { //This will always switch the form start, if it finds another [ after this
-                if (inMarkupTag && enableStrictParsing) { //If we're still tracking, this means we have nested form start
-                    int j = i + 3;
-                    if (j < len){
-                        String shorthand = stringToParse.substring(i,  i + 3);
-                        if (!shorthand.equals(MARKUP_ESCAPE)){
-                            throw new ParseProblemException("Nested tag detected at index: " + i);
-                        }
-                    }
-                }
-                tagStart = i;
-                inMarkupTag = true;
+                //If we're still tracking, this means we have nested tag, just skip it
+                fcDepth = 0; //Next form start, reset fc depth
+                idx = i;
+                ++fsDepth;
             }
 
-            if (c == FORM_CLOSE && inMarkupTag) { //Only parse the string if we're still tracking the valid tag
-                final String markupTag = stringToParse.substring(tagStart, i + 1); //Parse the extracted string and skip the braces
-                final List<AnsiCode> validStyles = this.getValidStyles(markupTag, delimiter, enableStrictParsing);
-                if (validStyles != null && !validStyles.isEmpty()) {
-                    tokens.add(new ParseToken(tagStart, i, validStyles));
-                    formTags.add(markupTag);
-                    inMarkupTag = false;
+            if (c == FORM_CLOSE) { //Only parse the string if we're still tracking the valid tag
+                ++fcDepth;
+
+                if (fsDepth == 1 && fcDepth == 1){ //Only if we dont have nested tags, with both open and closed tags
+                    final String fullTag = stringToParse.substring(idx, i + 1); //Parse the extracted string and skip the braces
+                    final List<AnsiCode> validStyles = this.getValidStyles(fullTag, delimiter, enableStrictParsing);
+                    if (!validStyles.isEmpty()) {
+                        tokens.add(new ParseToken(idx, i, validStyles));
+                        formTags.add(fullTag);
+                    }
                 }
+                --fsDepth;
             }
         }
 
         return new ParseResult(tokens, formTags);
     }
 
+    /*
+    * [red] valid, will get parsed
+    * [notastyle] valid, won't get parsed
+    * [nested[nested]] won't get parsed
+    * [not closed [red, blue] hello    //Read nor blue will get parsed
+    * */
+
 
     //Check if there are valid styles in the extracted string
     //ESP -> Enable strict parsing
     private List<AnsiCode> getValidStyles(String extractedStr, String delimiter, boolean esp) {
-        if (extractedStr.length() <= 2) return null;  //Check if the extracted string is just empty braces
+        if (extractedStr.length() <= 2) return List.of();  //Check if the extracted string is just empty braces, or a malformed tag
         extractedStr = this.cleanString(extractedStr); //Clean the string
 
         final String[] styles = extractedStr.split(Pattern.quote(delimiter));

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImpl.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImpl.java
@@ -3,6 +3,7 @@ package io.github.kusoroadeolu.clique.parser;
 
 import io.github.kusoroadeolu.clique.config.ParserConfiguration;
 import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
+import io.github.kusoroadeolu.clique.core.parser.MarkupPreProcessor;
 import io.github.kusoroadeolu.clique.core.parser.ParseResult;
 import io.github.kusoroadeolu.clique.core.parser.StyleApplicator;
 import io.github.kusoroadeolu.clique.core.parser.TokenExtractor;
@@ -14,6 +15,7 @@ import static io.github.kusoroadeolu.clique.core.utils.StringUtils.stripAnsi;
 public record AnsiStringParserImpl(ParserConfiguration parserConfiguration) implements AnsiStringParser {
     private static final StyleApplicator STYLE_APPLICATOR = new StyleApplicator();
     private static final TokenExtractor TOKEN_EXTRACTOR = new TokenExtractor();
+    private static final MarkupPreProcessor PROCESSOR = new MarkupPreProcessor();
 
 
     public AnsiStringParserImpl() {
@@ -21,9 +23,12 @@ public record AnsiStringParserImpl(ParserConfiguration parserConfiguration) impl
     }
 
     public String parse(String stringToParse) {
-        if (stringToParse == null || stringToParse.isBlank()) return EMPTY;
-        final ParseResult result = this.getParseResult(stringToParse);
-        return STYLE_APPLICATOR.restyleString(result.tokens(), stringToParse, this.parserConfiguration.getEnableAutoCloseTags());
+        if (stringToParse == null || stringToParse.isBlank()) return stringToParse;
+        String processed = PROCESSOR.preProcess(stringToParse);
+        final ParseResult result = this.getParseResult(processed);
+        String styled = STYLE_APPLICATOR.restyleString(result.tokens(), processed, this.parserConfiguration.getEnableAutoCloseTags());
+        return PROCESSOR.postProcess(styled);
+
     }
 
     public String parse(Object object) {
@@ -31,17 +36,18 @@ public record AnsiStringParserImpl(ParserConfiguration parserConfiguration) impl
     }
 
     public String getOriginalString(String tokenedString) {
-        if (tokenedString == null || tokenedString.isBlank()) return EMPTY;
-        var result = this.getParseResult(tokenedString);
+        if (tokenedString == null || tokenedString.isBlank()) return tokenedString;
+        String processed = PROCESSOR.preProcess(tokenedString);
+        ParseResult result = this.getParseResult(processed);
 
+        String piped;
         if (result.isPresent()){
-            var piped = result.extractedFormTags().stream()
-                    .reduce(tokenedString, (s, tag) -> s.replace(tag, EMPTY));
-            return stripAnsi(piped);
-
+            piped = result.extractedFormTags().stream().reduce(processed, (s, tag) -> s.replace(tag, EMPTY));
+        }else {
+            piped = tokenedString;
         }
 
-        return stripAnsi(tokenedString);
+        return stripAnsi(PROCESSOR.postProcess(piped));
     }
 
     ParseResult getParseResult(String input) {

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImpl.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImpl.java
@@ -3,10 +3,9 @@ package io.github.kusoroadeolu.clique.parser;
 
 import io.github.kusoroadeolu.clique.config.ParserConfiguration;
 import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
-import io.github.kusoroadeolu.clique.core.parser.MarkupPreProcessor;
-import io.github.kusoroadeolu.clique.core.parser.ParseResult;
-import io.github.kusoroadeolu.clique.core.parser.StyleApplicator;
-import io.github.kusoroadeolu.clique.core.parser.TokenExtractor;
+import io.github.kusoroadeolu.clique.core.parser.*;
+
+import java.util.List;
 
 import static io.github.kusoroadeolu.clique.core.utils.Constants.EMPTY;
 import static io.github.kusoroadeolu.clique.core.utils.StringUtils.stripAnsi;
@@ -40,14 +39,19 @@ public record AnsiStringParserImpl(ParserConfiguration parserConfiguration) impl
         String processed = PROCESSOR.preProcess(tokenedString);
         ParseResult result = this.getParseResult(processed);
 
-        String piped;
-        if (result.isPresent()){
-            piped = result.extractedFormTags().stream().reduce(processed, (s, tag) -> s.replace(tag, EMPTY));
-        }else {
-            piped = tokenedString;
-        }
+        if (!result.isPresent()) return stripAnsi(PROCESSOR.postProcess(tokenedString));
 
-        return stripAnsi(PROCESSOR.postProcess(piped));
+        final List<ParseToken> tokens = result.tokens();
+        final StringBuilder sb = new StringBuilder(processed.length());
+        int cursor = 0;
+
+        for (ParseToken token : tokens) {
+            sb.append(processed, cursor, token.start());
+            cursor = token.end() + 1;
+        }
+        sb.append(processed, cursor, processed.length());
+
+        return stripAnsi(PROCESSOR.postProcess(sb.toString()));
     }
 
     ParseResult getParseResult(String input) {

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/style/StyleBuilder.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/style/StyleBuilder.java
@@ -36,7 +36,7 @@ public sealed interface StyleBuilder extends Borderless permits DefaultStyleBuil
      * Appends multiple ANSI Codes to this text
      *
      * @param text      The text we're appending to the style builder
-     * @param ansiCodes The ansiCodes we're applying to the text
+     * @param ansiCodes The styles we're applying to the text
      * @return The instance of this class
      *
      */

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImplTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImplTest.java
@@ -130,6 +130,16 @@ class AnsiStringParserImplTest {
     }
 
     @Test
+    void onNullString(){
+        ParserConfiguration config = ParserConfiguration.builder()
+                .enableStrictParsing()
+                .build();
+
+        AnsiStringParser parser = Clique.parser(config);
+        parser.print("Coords: [*blue]Hello[/]"); // throws ParseProblemException
+    }
+
+    @Test
     void onNullString_returnsEmptyString(){
         var parser = AnsiStringParser.DEFAULT;
         var string = parser.parse(null);

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImplTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImplTest.java
@@ -17,14 +17,13 @@ import static org.junit.jupiter.api.Assertions.*;
 class AnsiStringParserImplTest {
 
     @Test
-    @Disabled("Fails in Maven Surefire due to unknown JVM fork issue - works in integration tests")
     void testCustomDelimiter() {
         ParserConfiguration config = ParserConfiguration
                 .builder()
                 .delimiter(' ')
                 .build();
         AnsiStringParser parser = new AnsiStringParserImpl(config);
-        String output = parser.parse("[red, bold]Text[/]");
+        String output = parser.parse("[red bold]Text[/]");
         assertTrue(output.contains(ColorCode.RED.toString()));
         assertTrue(output.contains(StyleCode.BOLD.toString()));
     }
@@ -80,12 +79,12 @@ class AnsiStringParserImplTest {
     }
 
     @Test
-    void testStrictParsing() {
+    void strictParsing_onUnidentifiedStyle_shouldThrow() {
         ParserConfiguration config = ParserConfiguration
                 .builder()
                 .enableStrictParsing()
                 .build();
-                new AnsiStringParserImpl(config).print("[[[red]]][blue]Hello");
+
     }
 
 
@@ -133,7 +132,7 @@ class AnsiStringParserImplTest {
     void onNullString_returnsEmptyString(){
         var parser = AnsiStringParser.DEFAULT;
         var string = parser.parse(null);
-        assertTrue(string.isEmpty());
+        assertNull(string);
     }
 
 

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImplTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImplTest.java
@@ -85,8 +85,7 @@ class AnsiStringParserImplTest {
                 .builder()
                 .enableStrictParsing()
                 .build();
-        assertThrows(ParseProblemException.class,
-                () -> new AnsiStringParserImpl(config).parse("[[[red]]]"));
+                new AnsiStringParserImpl(config).print("[[[red]]][blue]Hello");
     }
 
 
@@ -129,15 +128,6 @@ class AnsiStringParserImplTest {
         assertEquals("Hello", parser.getOriginalString(string));
     }
 
-    @Test
-    void onNullString(){
-        ParserConfiguration config = ParserConfiguration.builder()
-                .enableStrictParsing()
-                .build();
-
-        AnsiStringParser parser = Clique.parser(config);
-        parser.print("Coords: [*blue]Hello[/]"); // throws ParseProblemException
-    }
 
     @Test
     void onNullString_returnsEmptyString(){
@@ -145,6 +135,8 @@ class AnsiStringParserImplTest {
         var string = parser.parse(null);
         assertTrue(string.isEmpty());
     }
+
+
 
 }
 

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/TokenExtractorTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/TokenExtractorTest.java
@@ -1,34 +1,224 @@
 package io.github.kusoroadeolu.clique.parser;
 
 import io.github.kusoroadeolu.clique.Clique;
-import io.github.kusoroadeolu.clique.ansi.ColorCode;
-import io.github.kusoroadeolu.clique.core.parser.ParseResult;
+import io.github.kusoroadeolu.clique.ansi.StyleCode;
+import io.github.kusoroadeolu.clique.core.exceptions.UnidentifiedStyleException;
 import io.github.kusoroadeolu.clique.core.parser.TokenExtractor;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import static org.junit.jupiter.api.Assertions.*;
 
 class TokenExtractorTest {
 
+    private TokenExtractor extractor;
+    private static final String DELIMITER = ",";
+
+    @BeforeEach
+    void setUp() {
+        extractor = new TokenExtractor();
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
     @Test
-    void testTokenExtraction() {
-        String input = "[red, bold]Text[/]";
-        var tokenExtractor = new TokenExtractor();
-        ParseResult result = tokenExtractor.getParseResult(input, ",", false);
+    void singleValidTag_producesOneToken() {
+        var result = extractor.getParseResult("[red]hello[/]", DELIMITER, false);
+        assertEquals(2, result.tokens().size()); // [red] and [/]
+    }
+
+    @Test
+    void multipleValidTags_producesCorrectTokenCount() {
+        var result = extractor.getParseResult("[red]hello[/] [bold]world[/]", DELIMITER, false);
+        assertEquals(4, result.tokens().size());
+    }
+
+    @Test
+    void combinedStyles_allResolve() {
+        var result = extractor.getParseResult("[red, bold, ul]text[/]", DELIMITER, false);
+        assertEquals(2, result.tokens().size()); //red bold ul + reset
+        assertEquals(3, result.tokens().getFirst().styles().size());
+    }
+
+    @Test
+    void brightColor_resolvesCorrectly() {
+        var result = extractor.getParseResult("[*red]text[/]", DELIMITER, false);
         assertEquals(2, result.tokens().size());
-        assertEquals(2, result.tokens().getFirst().validStyles().size());
     }
 
     @Test
-    void testColorCodeOutput() {
-        assertEquals("\u001B[31m", ColorCode.RED.toString());
+    void backgroundColor_resolvesCorrectly() {
+        var result = extractor.getParseResult("[bg_red]text[/]", DELIMITER, false);
+        assertEquals(2, result.tokens().size());
     }
 
-    // Original string extraction
     @Test
-    void testGetOriginalString() {
-        var parser = Clique.parser();
-        assertEquals("Hello World", parser.getOriginalString("[red]Hello[/] World"));
+    void brightBackground_resolvesCorrectly() {
+        var result = extractor.getParseResult("[*bg_red]text[/]", DELIMITER, false);
+        assertEquals(2, result.tokens().size());
     }
 
+    @Test
+    void resetTag_resolvesCorrectly() {
+        var result = extractor.getParseResult("[/]", DELIMITER, false);
+        assertEquals(1, result.tokens().size());
+    }
+
+    @Test
+    void spaceDelimiter_resolvesStyles() {
+        var result = extractor.getParseResult("[red bold]text[/]", " ", false);
+        assertEquals(2, result.tokens().size());
+        assertEquals(2, result.tokens().getFirst().styles().size());
+    }
+
+    // ── Malformed / edge case input ───────────────────────────────────────────
+
+    @Test
+    void nullInput_returnsEmptyResult() {
+        var result = extractor.getParseResult(null, DELIMITER, false);
+        assertTrue(result.tokens().isEmpty());
+        assertTrue(result.extractedFormTags().isEmpty());
+    }
+
+    @Test
+    void emptyString_returnsEmptyResult() {
+        var result = extractor.getParseResult("", DELIMITER, false);
+        assertTrue(result.tokens().isEmpty());
+    }
+
+    @Test
+    void noTags_returnsEmptyResult() {
+        var result = extractor.getParseResult("just plain text", DELIMITER, false);
+        assertTrue(result.tokens().isEmpty());
+    }
+
+    @Test
+    void emptyBrackets_producesNoToken() {
+        var result = extractor.getParseResult("[]text", DELIMITER, false);
+        assertTrue(result.tokens().isEmpty());
+    }
+
+    @Test
+    void unknownStyle_lenientMode_isIgnored() {
+        var result = extractor.getParseResult("[unknownstyle]text[/]", DELIMITER, false);
+        // unknown tag should produce no token, not throw
+        assertDoesNotThrow(() -> extractor.getParseResult("[unknownstyle]text[/]", DELIMITER, false));
+        assertEquals(1, result.tokens().size()); //RESET TAG, unknown tag is ignored
+        assertEquals(StyleCode.RESET, result.tokens().getFirst().styles().getFirst());
+    }
+
+    @Test
+    void unknownStyle_strictMode_throws() {
+        assertThrows(UnidentifiedStyleException.class,
+                () -> extractor.getParseResult("[bol]text[/]", DELIMITER, true));
+    }
+
+    @Test
+    void unclosedTag_doesNotProduceToken() {
+        // [red with no closing ] — should not blow up, just no token
+        assertDoesNotThrow(() -> extractor.getParseResult("[red hello", DELIMITER, false));
+        var result = extractor.getParseResult("[red hello", DELIMITER, false);
+        assertTrue(result.tokens().isEmpty());
+    }
+
+    @Test
+    void unopenedClosingBracket_isIgnored() {
+        var result = extractor.getParseResult("text]more text", DELIMITER, false);
+        assertTrue(result.tokens().isEmpty());
+    }
+
+    @Test
+    void nestedBrackets_outerTagSkipped() {
+        // [[red]] — nested, should be skipped entirely
+        var result = extractor.getParseResult("[[red]]text", DELIMITER, false);
+        assertTrue(result.tokens().isEmpty());
+    }
+
+    @Test
+    void nestedBrackets_subsequentTagsAreIgnored() {
+        // After a nested/bad tag, valid tags after it should still work
+        var result = extractor.getParseResult("[[red]] [bold]text[/]", DELIMITER, false);
+        Clique.parser().print("[[red]] [bold]text[/]");
+    }
+
+    @Test
+    void deeplyNestedBrackets_handledGracefully() {
+        assertDoesNotThrow(() -> extractor.getParseResult("[[[[red]]]]text", DELIMITER, false));
+    }
+
+    // ── Whitespace handling ───────────────────────────────────────────────────
+
+    @Test
+    void stylesWithExtraWhitespace_stillResolve() {
+        var result = extractor.getParseResult("[ red , bold ]text[/]", DELIMITER, false);
+        assertEquals(2, result.tokens().size());
+        assertEquals(2, result.tokens().getFirst().styles().size());
+    }
+
+    @Test
+    void uppercaseStyles_resolveCorrectly() {
+        // parser lowercases internally, so [RED] should work
+        var result = extractor.getParseResult("[RED]text[/]", DELIMITER, false);
+        assertEquals(2, result.tokens().size());
+    }
+
+    // ── Stress / volume ───────────────────────────────────────────────────────
+
+    @Test
+    void manyTagsInOneString_allResolved() {
+        String input = "[red]a[/][bold]b[/][cyan]c[/][ul]d[/][italic]e[/]".repeat(100);
+        var result = extractor.getParseResult(input, DELIMITER, false);
+        assertEquals(1000, result.tokens().size()); // 5 tags * 2 ([open] + [/]) * 100
+    }
+
+    @Test
+    void veryLongStringNoTags_handledEfficiently() {
+        String input = "a".repeat(100_000);
+        assertDoesNotThrow(() -> extractor.getParseResult(input, DELIMITER, false));
+    }
+
+    @Test
+    void veryLongStringWithTags_parsesCorrectly() {
+        String chunk = "[red]hello world[/] ";
+        String input = chunk.repeat(10_000);
+        var result = extractor.getParseResult(input, DELIMITER, false);
+        assertEquals(20_000, result.tokens().size());
+    }
+
+    // ── Token position correctness ────────────────────────────────────────────
+
+    @Test
+    void tokenStartPosition_isCorrect() {
+        var result = extractor.getParseResult("[red]text[/]", DELIMITER, false);
+        assertEquals(0, result.tokens().get(0).start());
+    }
+
+    @Test
+    void tokenEndPosition_isCorrect() {
+        // [red] ends at index 4 (inclusive)
+        var result = extractor.getParseResult("[red]text[/]", DELIMITER, false);
+        assertEquals(4, result.tokens().get(0).end());
+    }
+
+    @Test
+    void formTagsAndTokens_haveSameSize() {
+        var result = extractor.getParseResult("[red]hello[/] [bold]world[/]", DELIMITER, false);
+        assertEquals(result.tokens().size(), result.extractedFormTags().size());
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "bold", "dim", "italic", "ul", "rv", "inv", "/", "dbl_ul", "strike",
+            "red", "green", "yellow", "blue", "magenta", "cyan", "white", "black",
+            "*red", "*green", "*blue", "*cyan", "*magenta", "*yellow", "*white", "*black",
+            "bg_red", "bg_green", "bg_blue", "bg_yellow", "bg_magenta", "bg_cyan", "bg_white", "bg_black",
+            "*bg_red", "*bg_green", "*bg_blue"
+    })
+    void allBuiltInStyles_resolveWithoutError(String style) {
+        String input = "[%s]text[/]".formatted(style);
+        assertDoesNotThrow(() -> extractor.getParseResult(input, DELIMITER, false));
+        var result = extractor.getParseResult(input, DELIMITER, false);
+        assertFalse(result.tokens().isEmpty(), "Expected token for style: " + style);
+    }
 }

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -18,10 +18,20 @@ System.out.println(styled);
 After parsing, you can retrieve the original text without markup tags:
 ```java
 AnsiStringParser parser = Clique.parser();
-parser.parse("[red, bold]Hello[/] World");
 String original = parser.getOriginalString("[red, bold]Hello[/] World"); // Returns "Hello World"
 ```
 
+## Parser Rules
+
+The parser follows a simple, predictable set of rules:
+
+- `[red]` — valid, will be parsed and styled
+- `[notastyle]` — valid syntax, but unrecognized style; passed through as-is
+- `[nested[nested]]` — nested tags are not supported; passed through as-is
+- `[not closed [red, blue] hello` — if a `[` is encountered before the current tag closes, the whole thing is ignored
+- `\\[red]` — escaped bracket; rendered as literal `[red]`
+
+The parser follows an **all or nothing** rule per tag — if a tag can't be cleanly parsed, it is left entirely untouched.
 
 ## Parser Configuration
 
@@ -29,7 +39,7 @@ Customize how the parser behaves using `ParserConfiguration`:
 ```java
 ParserConfiguration configuration = ParserConfiguration
         .builder()
-        .enableAutoCloseTags()  // Automatically close unclosed tags
+        .enableAutoCloseTags()  // Automatically reset styles between tags to prevent leaking
         .delimiter(' ')          // Use space instead of comma as delimiter
         .build();
 
@@ -42,15 +52,15 @@ configuredParser.print("[red bold]Hello[blue] World");
 ### Configuration Options
 
 - **`delimiter(char)`** - Set the delimiter between style attributes (default: `,`)
-- **`enableAutoCloseTags()`** - Automatically close tags that aren't explicitly closed
-- **`enableStrictParsing()`** - Throw exceptions for invalid styles or malformed tags
+- **`enableAutoCloseTags()`** - Automatically resets styles when a new tag is encountered, preventing styles from leaking into subsequent tags
+- **`enableStrictParsing()`** - Throw exceptions for unrecognized styles on otherwise valid tags
 
 ## Parser Exceptions
-When strict parsing is enabled, the parser can throw exceptions for invalid tags:
+When strict parsing is enabled, the parser throws exceptions for unrecognized styles on valid tags:
 
 ### UnidentifiedStyleException
 
-Thrown when you use a style that doesn't exist:
+Thrown when a valid tag contains a style that doesn't exist:
 ```java
 ParserConfiguration config = ParserConfiguration.builder()
     .enableStrictParsing()
@@ -58,44 +68,32 @@ ParserConfiguration config = ParserConfiguration.builder()
     
 AnsiStringParser parser = Clique.parser(config);
 
-// This throws UnidentifiedStyleException because "bol" doesn't exist
+// Throws UnidentifiedStyleException because "bol" is not a recognized style
 parser.parse("[red, bol]Text[/]");
 ```
 
-### ParseProblemException
-
-Thrown when tags are malformed:
-```java
-// Nested brackets cause parsing issues
-parser.parse("[[[red]]]Text[/]");
-```
-
-**Note:** Without strict parsing enabled, invalid styles are simply ignored and printed as is
+**Note:** Without strict parsing enabled, unrecognized styles are ignored and the text is passed through as-is. Malformed or structurally invalid tags are always passed through regardless of strict mode.
 
 ## Escaping Special Characters
 
-Since `[]` brackets are used for markup tags, you need to escape them when displaying literal brackets.
+Since `[]` brackets are used for markup tags, you can escape them with a backslash to display literal brackets.
 
 ### Escaping Brackets
-
-To display literal brackets, use `[/]` to close the tag interpretation:
 ```java
-// Display literal [123, 456]
-Clique.parser().print("[123, 456[/]]");
+// Display literal [red]
+Clique.parser().print("\\[red]");
 ```
-
-**Pattern:** `[your text with brackets[/]]`
 
 **Examples:**
 ```java
-"[red, bold[/]]"        // Displays: [red, bold]
-"[x, y, z[/]]"          // Displays: [x, y, z]
-"Coords: [10, 20[/]]"   // Displays: Coords: [10, 20]
+"\\[red]"               // Displays: [red]
+"\\[red, bold]"         // Displays: [red, bold]
+"Coords: \\[10, 20]"    // Displays: Coords: [10, 20]
 ```
 
 ## Markup Syntax Reference
 
-See [markup-reference.md](markup-reference.md) for a complete list of supported colors, background colors, and text styles.
+See [markup-reference.md](markup-reference.md) for a complete list of default supported colors, background colors, and text styles.
 
 ## Using Parser with Other Features
 


### PR DESCRIPTION
Closes: #34 

## Summary
Redesigns the parser rules and escape syntax for clarity and predictability, fixes strict parsing being too aggressive, and adds preprocessing support for the new escape mechanism.

---

## Changes

### Parser Rule Redesign
Formalized a clear, simple set of parsing rules:
- Valid tags with recognized styles are parsed and styled
- Valid tags with unrecognized styles are passed through as-is
- Nested tags are not supported and passed through as-is
- Tags interrupted by another `[` before closing are ignored entirely
- Escaped brackets render as literal text

The parser now follows a strict **all or nothing** principle per tag — if a tag can't be cleanly parsed, it is left entirely untouched.

### Escape Syntax
Replaced the old `[content[/]]` escape mechanism with the more intuitive backslash escape:
```
\[red]  →  displays [red]
```

### `MarkupPreProcessor`
Added preprocessing step in the parse pipeline that:
- Replaces `\[` with an internal placeholder before tokenization
- Restores the placeholder to `[` after styling is applied

This keeps `TokenExtractor` completely unaware of escape logic.

### Strict Parsing Fix
`enableStrictParsing` no longer throws on structurally unusual brackets or unrecognized content. It now only throws `UnidentifiedStyleException` when a **valid, recognized tag** contains an unrecognized style. Malformed or unrecognized tags are always passed through regardless of strict mode.

### `enableAutoCloseTags` Clarification
Corrected the behavior description — this option resets styles when a new tag is encountered to prevent style leaking, not to automatically close malformed tags.

### Docs
Updated `parser.md` to reflect all of the above, including the new parser rules section, corrected configuration descriptions, and the new escape syntax.

---

## Breaking Changes
- Old escape syntax `[content[/]]` is removed in favor of `\[`