### PR TITLE
Feat/iterable pg bar

### DIFF
--- a/Changelogs.md
+++ b/Changelogs.md
@@ -115,7 +115,7 @@ Changes to the SPI module in this release.
 - `BoxConfigurationBuilder#padding()` now returns the builder reference for fluent chaining
 - `BoxConfiguration` `equals()`, `hashCode()`, and `toString()` now include `padding`
 - `BorderStyle` now holds a `BorderColor` internally instead of raw `AnsiCode` arrays
-- `Clique` facade overloads now accept `BorderSpec` instead of `AnsiCode` arrays directly
+- `Clique` facade overloads now accept `BorderSpec` instead of a `BorderStyle`
 - `builder()` is now the standard entry point for all configuration classes
 - Parser escape syntax replaced — `[content[/]]` is removed in favor of `\[` (e.g. `\[red]` renders as `[red]`)
 - `enableAutoCloseTags` now correctly described as style leak prevention — resets styles when a new tag is encountered rather than forgiving malformed tags

--- a/Changelogs.md
+++ b/Changelogs.md
@@ -1,4 +1,4 @@
-**# Changelog
+# Changelog
 
 ## Clique [3.1.0] - 2026-03-21
 
@@ -131,4 +131,25 @@ Changes to the SPI module in this release.
 
 ## clique-spi [1.0.5] - 2026-03-30
 
-Report issues at: https://github.com/kusoroadeolu/Clique/issues**
+
+# Changelogs
+
+## Clique [3.2.1] - 2026-04-01
+
+### Added
+- `IterableProgressBar<T>` — wraps a `Collection<T>` and implements `Iterable<T>`, ticking and rendering automatically on each iteration. Single-use; throws `IllegalStateException` if iterated more than once
+- New `Clique#progressBar(Collection<T>)` factory overloads:
+    - `progressBar(Collection<T>)` — default configuration
+    - `progressBar(Collection<T>, ProgressBarConfiguration)` — custom configuration
+    - `progressBar(Collection<T>, ProgressBarPreset)` — predefined preset
+
+### Changed
+- `ProgressBar#tick()` now calls `render` on each tick call
+- `ProgressBarConfiguration#styleRange(min, max)`, max now includes the max range as part of the style range
+
+### Fixed
+- `ProgressBar#complete()` no longer throws an exception when called on an already-completed bar
+- Passing a null parser no longer causes a NullPointerException during style resolution
+- 
+Report issues at: https://github.com/kusoroadeolu/Clique/issues
+

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/Clique.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/Clique.java
@@ -10,6 +10,7 @@ import io.github.kusoroadeolu.clique.core.utils.AnsiDetector;
 import io.github.kusoroadeolu.clique.frame.Frame;
 import io.github.kusoroadeolu.clique.indent.Indenter;
 import io.github.kusoroadeolu.clique.parser.AnsiStringParser;
+import io.github.kusoroadeolu.clique.progressbar.IterableProgressBar;
 import io.github.kusoroadeolu.clique.progressbar.ProgressBar;
 import io.github.kusoroadeolu.clique.progressbar.ProgressBarPreset;
 import io.github.kusoroadeolu.clique.spi.AnsiCode;
@@ -76,6 +77,19 @@ public final class Clique {
     public static ProgressBar progressBar(int total, EasingConfiguration easing){
         return CliqueComponents.progressBar(total, easing);
     }
+
+    public static <T> IterableProgressBar<T> progressBar(Collection<T> collection) {
+        return CliqueComponents.progressBar(collection);
+    }
+
+    public static <T>IterableProgressBar<T> progressBar(Collection<T> collection, ProgressBarConfiguration configuration) {
+        return CliqueComponents.progressBar(collection, configuration);
+    }
+
+    public static  <T>IterableProgressBar<T> progressBar(Collection<T> collection, ProgressBarPreset preset) {
+        return CliqueComponents.progressBar(collection, preset.getConfiguration());
+    }
+
 
     // FRAME
     public static Frame frame() { return CliqueComponents.frame(); }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/CliqueComponents.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/CliqueComponents.java
@@ -9,6 +9,7 @@ import io.github.kusoroadeolu.clique.frame.DefaultFrame;
 import io.github.kusoroadeolu.clique.frame.Frame;
 import io.github.kusoroadeolu.clique.indent.DefaultIndenter;
 import io.github.kusoroadeolu.clique.indent.Indenter;
+import io.github.kusoroadeolu.clique.progressbar.IterableProgressBar;
 import io.github.kusoroadeolu.clique.progressbar.ProgressBar;
 import io.github.kusoroadeolu.clique.progressbar.ProgressBarPreset;
 import io.github.kusoroadeolu.clique.tables.AbstractTable.CustomizableTableHeaderBuilder;
@@ -16,6 +17,8 @@ import io.github.kusoroadeolu.clique.tables.AbstractTable.TableHeaderBuilder;
 import io.github.kusoroadeolu.clique.tables.TableFactory;
 import io.github.kusoroadeolu.clique.tables.TableType;
 import io.github.kusoroadeolu.clique.tree.Tree;
+
+import java.util.Collection;
 
 /**
  * Sub-facade for all rendering components: boxes, tables, frames, trees, indenters, and progress bars.
@@ -109,6 +112,17 @@ final class CliqueComponents {
     public static ProgressBar progressBar(int total, EasingConfiguration easing) {
         return new ProgressBar(total, ProgressBarConfiguration.fromEasing(easing));
     }
+
+    public static <T>IterableProgressBar<T> progressBar(Collection<T> collection) {
+        return new IterableProgressBar<>(collection);
+    }
+
+    public static <T>IterableProgressBar<T> progressBar(Collection<T> collection, ProgressBarConfiguration configuration) {
+        return new IterableProgressBar<>(collection, configuration);
+    }
+
+
+
 
 
     // FRAME

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/CliqueStyles.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/CliqueStyles.java
@@ -1,6 +1,6 @@
 package io.github.kusoroadeolu.clique;
 
-import io.github.kusoroadeolu.clique.ansi.RGBAnsiColor;
+import io.github.kusoroadeolu.clique.ansi.RGBColor;
 import io.github.kusoroadeolu.clique.config.ParserConfiguration;
 import io.github.kusoroadeolu.clique.core.parser.GlobalStyleRegistry;
 import io.github.kusoroadeolu.clique.parser.AnsiStringParser;
@@ -45,11 +45,11 @@ final class CliqueStyles {
     // RGB
 
     public static RGBAnsiCode rgb(int r, int g, int b) {
-        return new RGBAnsiColor(r, g, b, false);
+        return new RGBColor(r, g, b, false);
     }
 
     public static RGBAnsiCode rgb(int r, int g, int b, boolean background) {
-        return new RGBAnsiColor(r, g, b, background);
+        return new RGBColor(r, g, b, background);
     }
 
     // STYLE REGISTRATION

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/Main.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/Main.java
@@ -1,0 +1,20 @@
+package io.github.kusoroadeolu.clique;
+
+import io.github.kusoroadeolu.clique.config.ProgressBarConfiguration;
+import io.github.kusoroadeolu.clique.progressbar.ProgressBar;
+
+public class Main {
+    public static void main(String[] args) throws InterruptedException {
+        ProgressBarConfiguration config = ProgressBarConfiguration.builder()
+                .styleRange(0, 30, "[red]:bar[/] :percent% [red]Starting...[/]")
+                .styleRange(30, 70, "[yellow]:bar[/] :percent% [yellow]In Progress...[/]")
+                .styleRange(70, 100, "[green]:bar[/] :percent% [green]Almost Done![/]")
+                .build();
+
+        ProgressBar bar = Clique.progressBar(100, config);
+        while (!bar.isDone()){
+            bar.tick();
+            Thread.sleep(100);
+        }
+    }
+}

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/ansi/RGBColor.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/ansi/RGBColor.java
@@ -4,9 +4,9 @@ import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
 import io.github.kusoroadeolu.clique.spi.RGBAnsiCode;
 
 @InternalApi(since = "3.2.0")
-public record RGBAnsiColor(int red, int green, int blue, boolean isBackground) implements RGBAnsiCode {
+public record RGBColor(int red, int green, int blue, boolean isBackground) implements RGBAnsiCode {
     
-    public RGBAnsiColor {
+    public RGBColor {
         if (red < 0 || red > 255) throw new IllegalArgumentException("Red must be 0-255");
         if (green < 0 || green > 255) throw new IllegalArgumentException("Green must be 0-255");
         if (blue < 0 || blue > 255) throw new IllegalArgumentException("Blue must be 0-255");

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/ProgressBarConfiguration.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/ProgressBarConfiguration.java
@@ -49,6 +49,7 @@ public class ProgressBarConfiguration {
         return builder();
     }
 
+    @Stable(since = "3.2.1")
     public static ProgressBarConfigurationBuilder fromPreset(ProgressBarPreset preset) {
         Objects.requireNonNull(preset, "Preset cannot be null");
         var config = preset.getConfiguration();
@@ -70,6 +71,7 @@ public class ProgressBarConfiguration {
     }
 
     // Get the format based on current percent
+    @InternalApi(since = "3.2.1")
     public String getFormatForPercent(int percent) {
         return styles.stream()
                 .filter(style -> style.matches(percent))
@@ -174,7 +176,7 @@ public class ProgressBarConfiguration {
         public ProgressBarConfigurationBuilder styleRange(int min, int max, String format) {
             requireNonNull(format, "Format cannot be null");
             if (min < 0) throw new IllegalArgumentException("Min must be positive");
-            return this.styleWhen(p -> p >= min && p < max, format);
+            return this.styleWhen(p -> p >= min && p <= max, format);
         }
 
         public ProgressBarConfigurationBuilder styles(Collection<ProgressBarPredicate> styles) {

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/GlobalStyleRegistry.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/GlobalStyleRegistry.java
@@ -2,7 +2,6 @@ package io.github.kusoroadeolu.clique.core.parser;
 
 
 import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
-import io.github.kusoroadeolu.clique.core.documentation.Stable;
 import io.github.kusoroadeolu.clique.spi.AnsiCode;
 
 import java.util.Map;

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/TokenExtractor.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/TokenExtractor.java
@@ -1,7 +1,6 @@
 package io.github.kusoroadeolu.clique.core.parser;
 
 import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
-import io.github.kusoroadeolu.clique.core.exceptions.ParseProblemException;
 import io.github.kusoroadeolu.clique.core.exceptions.UnidentifiedStyleException;
 import io.github.kusoroadeolu.clique.spi.AnsiCode;
 

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/StringUtils.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/StringUtils.java
@@ -19,6 +19,11 @@ public final class StringUtils {
         else return new Cell(text, text);
     }
 
+    public static String parseString(String text, AnsiStringParser parser) {
+        if (parser != null) return parser.parse(text);
+        else return text;
+    }
+
     public static String stripAnsi(String styled) {
         int i = 0;
         boolean inAnsi = false;

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/frame/DefaultFrame.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/frame/DefaultFrame.java
@@ -57,7 +57,7 @@ public class DefaultFrame implements  Frame {
     }
 
     @Override
-    public DefaultFrame title(String title, FrameAlign titleAlign) {
+    public Frame title(String title, FrameAlign titleAlign) {
         Objects.requireNonNull(title, "Title cannot be null");
         Objects.requireNonNull(titleAlign, NULL_FRAME_ALIGN);
         this.title = title;
@@ -66,12 +66,12 @@ public class DefaultFrame implements  Frame {
     }
 
     @Override
-    public DefaultFrame title(String title) {
+    public Frame title(String title) {
         return title(title, FrameAlign.CENTER);
     }
 
     @Override
-    public DefaultFrame width(int width) {
+    public Frame width(int width) {
         if (width <= 0) throw new InvalidDimensionException(
                 "Frame width must be greater than zero, got: %d".formatted(width)
         );        this.width = width;
@@ -79,12 +79,12 @@ public class DefaultFrame implements  Frame {
     }
 
     @Override
-    public DefaultFrame nest(String str) {
+    public Frame nest(String str) {
         return nest(str, configuration.getFrameAlign());
     }
 
     @Override
-    public DefaultFrame nest(String str, FrameAlign align) {
+    public Frame nest(String str, FrameAlign align) {
         Objects.requireNonNull(str, "String cannot be null");
         Objects.requireNonNull(align, NULL_FRAME_ALIGN);
         if (configuration.getParser() != null) str = str + RESET;
@@ -93,12 +93,12 @@ public class DefaultFrame implements  Frame {
     }
 
     @Override
-    public DefaultFrame nest(Component component) {
+    public Frame nest(Component component) {
         return nest(component, configuration.getFrameAlign());
     }
 
     @Override
-    public DefaultFrame nest(Component component, FrameAlign align) {
+    public Frame nest(Component component, FrameAlign align) {
         Objects.requireNonNull(component, "Component cannot be null");
         Objects.requireNonNull(align, NULL_FRAME_ALIGN);
         nodes.add(new FrameNode.ComponentNode(component, align));

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/frame/Frame.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/frame/Frame.java
@@ -10,17 +10,17 @@ import io.github.kusoroadeolu.clique.core.documentation.Stable;
  * */
 @Stable(since = "3.2.0")
 public interface Frame extends Bordered{
-    DefaultFrame title(String title, FrameAlign titleAlign);
+    Frame title(String title, FrameAlign titleAlign);
 
-    DefaultFrame title(String title);
+    Frame title(String title);
 
-    DefaultFrame width(int width);
+    Frame width(int width);
 
-    DefaultFrame nest(String str);
+    Frame nest(String str);
 
-    DefaultFrame nest(String str, FrameAlign align);
+    Frame nest(String str, FrameAlign align);
 
-    DefaultFrame nest(Component component);
+    Frame nest(Component component);
 
-    DefaultFrame nest(Component component, FrameAlign align);
+    Frame nest(Component component, FrameAlign align);
 }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/indent/DefaultIndenter.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/indent/DefaultIndenter.java
@@ -11,7 +11,6 @@ import java.util.Deque;
 import java.util.Objects;
 
 import static io.github.kusoroadeolu.clique.core.utils.StringUtils.clearStringBuilder;
-import static io.github.kusoroadeolu.clique.core.utils.StringUtils.parseString;
 import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
 

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/indent/DefaultIndenter.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/indent/DefaultIndenter.java
@@ -3,6 +3,7 @@ package io.github.kusoroadeolu.clique.indent;
 import io.github.kusoroadeolu.clique.config.IndenterConfiguration;
 import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
 import io.github.kusoroadeolu.clique.core.utils.Constants;
+import io.github.kusoroadeolu.clique.core.utils.StringUtils;
 
 import java.util.ArrayDeque;
 import java.util.Collection;
@@ -10,6 +11,7 @@ import java.util.Deque;
 import java.util.Objects;
 
 import static io.github.kusoroadeolu.clique.core.utils.StringUtils.clearStringBuilder;
+import static io.github.kusoroadeolu.clique.core.utils.StringUtils.parseString;
 import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
 
@@ -122,11 +124,7 @@ public class DefaultIndenter implements Indenter {
     }
 
     private String parseString(String str) {
-        if (this.configuration.getParser() != null) {
-            str = this.configuration.getParser().parse(str);
-        }
-
-        return str;
+        return StringUtils.parseString(str, this.configuration.getParser());
     }
 
     public Indenter resetLevel() {

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImpl.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImpl.java
@@ -3,7 +3,6 @@ package io.github.kusoroadeolu.clique.parser;
 
 import io.github.kusoroadeolu.clique.config.ParserConfiguration;
 import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
-import io.github.kusoroadeolu.clique.core.documentation.Stable;
 import io.github.kusoroadeolu.clique.core.parser.*;
 
 import java.util.List;

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/progressbar/IterableProgressBar.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/progressbar/IterableProgressBar.java
@@ -1,0 +1,54 @@
+package io.github.kusoroadeolu.clique.progressbar;
+
+import io.github.kusoroadeolu.clique.config.ProgressBarConfiguration;
+import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Objects;
+
+/**
+ * @since 3.2.1
+ * */
+@InternalApi(since = "3.2.1")
+public class IterableProgressBar<T>  implements Iterable<T>{
+    private final Iterator<T> iterator;
+    boolean consumed = false;
+    final ProgressBar progressBar;
+
+
+    public IterableProgressBar(Collection<T> collection, ProgressBarConfiguration configuration){
+        Objects.requireNonNull(collection, "Collection cannot be null");
+        Objects.requireNonNull(configuration, "Parser configuration cannot be null");
+        this.iterator = collection.iterator();
+        progressBar = new ProgressBar(collection.size(), configuration);
+    }
+
+    public IterableProgressBar(Collection<T> collection){
+        this(collection, ProgressBarConfiguration.DEFAULT);
+    }
+
+
+    @Override
+    public Iterator<T> iterator() {
+        if (consumed) throw new IllegalStateException("IterableProgressBar can only be iterated once");
+        consumed = true;
+        return new ProgressBarIterator<>(this);
+    }
+
+
+    private record ProgressBarIterator<T>(IterableProgressBar<T> iterableProgressBar) implements Iterator<T> {
+
+        @Override
+            public boolean hasNext() {
+                return iterableProgressBar.iterator.hasNext();
+            }
+
+            @Override
+            public T next() {
+                T item = iterableProgressBar.iterator.next();
+                iterableProgressBar.progressBar.tick();
+                return item;
+            }
+        }
+}

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/progressbar/IterableProgressBar.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/progressbar/IterableProgressBar.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 @InternalApi(since = "3.2.1")
 public class IterableProgressBar<T>  implements Iterable<T>{
     private final Iterator<T> iterator;
-    boolean consumed = false;
+    private boolean consumed = false;
     final ProgressBar progressBar;
 
 
@@ -23,6 +23,8 @@ public class IterableProgressBar<T>  implements Iterable<T>{
         this.iterator = collection.iterator();
         progressBar = new ProgressBar(collection.size(), configuration);
     }
+
+
 
     public IterableProgressBar(Collection<T> collection){
         this(collection, ProgressBarConfiguration.DEFAULT);
@@ -36,7 +38,12 @@ public class IterableProgressBar<T>  implements Iterable<T>{
         return new ProgressBarIterator<>(this);
     }
 
+    public boolean isDone(){
+        return progressBar.isDone();
+    }
 
+
+    
     private record ProgressBarIterator<T>(IterableProgressBar<T> iterableProgressBar) implements Iterator<T> {
 
         @Override

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/progressbar/ProgressBar.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/progressbar/ProgressBar.java
@@ -6,6 +6,7 @@ import io.github.kusoroadeolu.clique.config.ProgressBarConfiguration;
 import io.github.kusoroadeolu.clique.core.display.Bordered;
 import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
 import io.github.kusoroadeolu.clique.core.documentation.Stable;
+import io.github.kusoroadeolu.clique.core.utils.StringUtils;
 
 import java.io.PrintStream;
 import java.util.Objects;
@@ -13,12 +14,14 @@ import java.util.concurrent.TimeUnit;
 
 import static io.github.kusoroadeolu.clique.core.utils.Constants.BLANK;
 import static io.github.kusoroadeolu.clique.core.utils.Constants.ZERO;
+import static io.github.kusoroadeolu.clique.core.utils.StringUtils.parseString;
+import static io.github.kusoroadeolu.clique.core.utils.StringUtils.parseToCell;
 
 /**
  * @since 3.0.0
  * */
 @InternalApi(since = "3.2.1")
-public final class ProgressBar implements Bordered {
+public class ProgressBar implements Bordered {
     final int total;
     final long creationTime;
     final ProgressBarConfiguration progressBarConfiguration;
@@ -51,10 +54,12 @@ public final class ProgressBar implements Bordered {
         return this.tick(1);
     }
 
+
     public ProgressBar tick(int amount) {
         if (amount < 1) throw new IllegalArgumentException("Tick amount cannot be less than 1");
         currentTick = Math.clamp(currentTick + amount, ZERO, total);
         if (currentTick >= total && !isDone) isDone = true;
+        this.render();
         return this;
     }
 
@@ -103,8 +108,10 @@ public final class ProgressBar implements Bordered {
         return isDone;
     }
 
+
+    //Modified this to first check if we can tick by an actual valid value
     public ProgressBar complete() {
-        return this.tick(total - currentTick);
+        return this.tick(Math.max(1, total - currentTick));
     }
 
     private int percent() {
@@ -174,7 +181,7 @@ public final class ProgressBar implements Bordered {
         var remaining = interval(remainingTime());
         format = format.replace(":remaining", remaining);
 
-        return this.progressBarConfiguration.parser().parse(format);
+        return parseString(format, this.progressBarConfiguration.parser());
     }
 
 

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/progressbar/ProgressBar.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/progressbar/ProgressBar.java
@@ -5,8 +5,6 @@ import io.github.kusoroadeolu.clique.config.EasingConfiguration;
 import io.github.kusoroadeolu.clique.config.ProgressBarConfiguration;
 import io.github.kusoroadeolu.clique.core.display.Bordered;
 import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
-import io.github.kusoroadeolu.clique.core.documentation.Stable;
-import io.github.kusoroadeolu.clique.core.utils.StringUtils;
 
 import java.io.PrintStream;
 import java.util.Objects;
@@ -15,7 +13,6 @@ import java.util.concurrent.TimeUnit;
 import static io.github.kusoroadeolu.clique.core.utils.Constants.BLANK;
 import static io.github.kusoroadeolu.clique.core.utils.Constants.ZERO;
 import static io.github.kusoroadeolu.clique.core.utils.StringUtils.parseString;
-import static io.github.kusoroadeolu.clique.core.utils.StringUtils.parseToCell;
 
 /**
  * @since 3.0.0

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/tables/Table.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/tables/Table.java
@@ -3,7 +3,6 @@ package io.github.kusoroadeolu.clique.tables;
 
 import io.github.kusoroadeolu.clique.core.display.Bordered;
 import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
-import io.github.kusoroadeolu.clique.core.documentation.Stable;
 
 import java.util.Collection;
 

--- a/clique-core/src/main/java/module-info.java
+++ b/clique-core/src/main/java/module-info.java
@@ -1,6 +1,5 @@
 module clique.core {
     requires clique.spi;
-    requires clique.core;
     uses io.github.kusoroadeolu.clique.spi.CliqueTheme;
     provides io.github.kusoroadeolu.clique.spi.CliqueTheme
             with io.github.kusoroadeolu.clique.themeloader.TestTheme;

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImplTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImplTest.java
@@ -5,7 +5,6 @@ import io.github.kusoroadeolu.clique.Clique;
 import io.github.kusoroadeolu.clique.ansi.ColorCode;
 import io.github.kusoroadeolu.clique.ansi.StyleCode;
 import io.github.kusoroadeolu.clique.config.ParserConfiguration;
-import io.github.kusoroadeolu.clique.core.exceptions.ParseProblemException;
 import io.github.kusoroadeolu.clique.core.exceptions.UnidentifiedStyleException;
 import io.github.kusoroadeolu.clique.core.parser.ParserUtils;
 import io.github.kusoroadeolu.clique.spi.AnsiCode;

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/TokenExtractorTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/TokenExtractorTest.java
@@ -4,9 +4,11 @@ import io.github.kusoroadeolu.clique.Clique;
 import io.github.kusoroadeolu.clique.ansi.StyleCode;
 import io.github.kusoroadeolu.clique.core.exceptions.UnidentifiedStyleException;
 import io.github.kusoroadeolu.clique.core.parser.TokenExtractor;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class TokenExtractorTest {

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/progressbar/IterableProgressBarTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/progressbar/IterableProgressBarTest.java
@@ -1,7 +1,42 @@
 package io.github.kusoroadeolu.clique.progressbar;
 
+import io.github.kusoroadeolu.clique.Clique;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class IterableProgressBarTest {
+
+    @Test
+    void test_whenIteratedOver_shouldBeDone(){
+        IterableProgressBar<Integer> iterable = Clique.progressBar(List.of(1,2,3,4,5));
+        for (int i : iterable){}
+        assertTrue(iterable.isDone());
+
+    }
+
+
+    @Test
+    void test_whenIteratedOverOnce_throwsOnSubsequentIterations(){
+        IterableProgressBar<Integer> iterable = Clique.progressBar(List.of(1,2,3,4,5));
+        for (int i : iterable){}
+
+        assertTrue(iterable.isDone());
+
+        assertThrows(IllegalStateException.class, () -> {
+            for (int i : iterable){}
+        });
+    }
+
+    @Test
+    void test_iteratorNext_shouldNotTick_beforeNextIsCalled(){
+        IterableProgressBar<Integer> iterable = Clique.progressBar(List.of(1,2 , 3));
+        var iterator = iterable.iterator();
+        assertTrue(iterable.progressBar.currentTick < 1);
+        iterator.next();
+        assertEquals(1, iterable.progressBar.currentTick);
+    }
 
 }

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/progressbar/IterableProgressBarTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/progressbar/IterableProgressBarTest.java
@@ -1,0 +1,7 @@
+package io.github.kusoroadeolu.clique.progressbar;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IterableProgressBarTest {
+
+}

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/progressbar/IterableProgressBarTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/progressbar/IterableProgressBarTest.java
@@ -12,7 +12,9 @@ class IterableProgressBarTest {
     @Test
     void test_whenIteratedOver_shouldBeDone(){
         IterableProgressBar<Integer> iterable = Clique.progressBar(List.of(1,2,3,4,5));
-        for (int i : iterable){}
+        for (int i : iterable){
+            //Do Nothing
+        }
         assertTrue(iterable.isDone());
 
     }
@@ -21,12 +23,17 @@ class IterableProgressBarTest {
     @Test
     void test_whenIteratedOverOnce_throwsOnSubsequentIterations(){
         IterableProgressBar<Integer> iterable = Clique.progressBar(List.of(1,2,3,4,5));
-        for (int i : iterable){}
+        for (int i : iterable){
+            //Do Nothing
+
+        }
 
         assertTrue(iterable.isDone());
 
         assertThrows(IllegalStateException.class, () -> {
-            for (int i : iterable){}
+            for (int i : iterable){
+                //Do Nothing
+            }
         });
     }
 

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/progressbar/ProgressBarTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/progressbar/ProgressBarTest.java
@@ -48,6 +48,14 @@ class ProgressBarTest {
         assertTrue(bar.isDone);
     }
 
+
+    @Test
+    void testComplete_whenComplete_completeCallShouldNotThrow(){
+        ProgressBar bar = new ProgressBar(100);
+        bar.tick(100);
+        assertDoesNotThrow(bar::complete);
+    }
+
     @Test
     void testPercentCalculation() {
         ProgressBar bar = new ProgressBar(100);

--- a/docs/progress-bars.md
+++ b/docs/progress-bars.md
@@ -5,13 +5,11 @@ Progress bars provide visual feedback for long-running operations. Clique includ
 ## Quick Start
 
 ### Basic Progress Bar
-
 ```java
 ProgressBar bar = Clique.progressBar(100);
 
 while (!bar.isDone()) {
     bar.tick();
-    bar.render();
     Thread.sleep(50);
 }
 ```
@@ -19,7 +17,6 @@ while (!bar.isDone()) {
 ### Using Predefined Presets
 
 Clique provides several built-in presets:
-
 ```java
 // Blocks style (default)
 ProgressBar bar = Clique.progressBar(100, ProgressBarPreset.BLOCKS);
@@ -36,6 +33,34 @@ ProgressBar bar = Clique.progressBar(100, ProgressBarPreset.CLASSIC);
 // Dots style
 ProgressBar bar = Clique.progressBar(100, ProgressBarPreset.DOTS);
 ```
+
+### Iterating Over a Collection
+
+When processing a collection, use `progressBar(collection)` to skip the boilerplate entirely. The total is inferred from the collection size, and the bar ticks and renders automatically on each iteration:
+```java
+for (var file : Clique.progressBar(files)) {
+    process(file);
+}
+```
+
+Presets and custom configuration are supported too:
+```java
+// With a preset
+for (var file : Clique.progressBar(files, ProgressBarPreset.DOTS)) {
+    process(file);
+}
+
+// With custom configuration
+ProgressBarConfiguration config = ProgressBarConfiguration.builder()
+    .format("[blue]:bar[/] :progress/:total files [:elapsed/:remaining]")
+    .build();
+
+for (var file : Clique.progressBar(files, config)) {
+    process(file);
+}
+```
+
+> **Note:** `IterableProgressBar` is single-use. Iterating over the same instance twice will throw an `IllegalStateException`.
 
 ## Predefined Styles
 
@@ -87,7 +112,6 @@ ProgressBar bar = Clique.progressBar(100, ProgressBarPreset.DOTS);
 ## Custom Configuration
 
 Build your own progress bar style using `ProgressBarConfiguration`:
-
 ```java
 ProgressBarConfiguration config = ProgressBarConfiguration.builder()
     .length(60)
@@ -137,13 +161,12 @@ Use a custom parser for markup processing:
 ## Dynamic Styling
 
 Change the format based on progress percentage:
-
 ```java
 ProgressBarConfiguration config = ProgressBarConfiguration.builder()
-    .styleRange(0, 30, "[red]:bar[/] :percent% [red]Starting...[/]")
-    .styleRange(30, 70, "[yellow]:bar[/] :percent% [yellow]In Progress...[/]")
-    .styleRange(70, 100, "[green]:bar[/] :percent% [green]Almost Done![/]")
-    .build();
+        .styleRange(0, 30, "[red]:bar[/] :percent% [red]Starting...[/]")
+        .styleRange(30, 70, "[yellow]:bar[/] :percent% [yellow]In Progress...[/]")
+        .styleRange(70, 100, "[green]:bar[/] :percent% [green]Almost Done![/]")
+        .build();
 
 ProgressBar bar = Clique.progressBar(100, config);
 ```
@@ -153,22 +176,22 @@ ProgressBar bar = Clique.progressBar(100, config);
 Use `styleWhen()` for custom conditions:
 ```java
 ProgressBarConfiguration config = ProgressBarConfiguration.builder()
-    .styleWhen(p -> p < 50, "[red]:bar[/] :percent%")
-    .styleWhen(p -> p >= 50 && p < 90, "[yellow]:bar[/] :percent%")
-    .styleWhen(p -> p >= 90, "[green]:bar[/] :percent%")
-    .build();
+        .styleWhen(p -> p < 50, "[red]:bar[/] :percent%")
+        .styleWhen(p -> p >= 50 && p < 90, "[yellow]:bar[/] :percent%")
+        .styleWhen(p -> p >= 90, "[green]:bar[/] :percent%")
+        .build();
 ```
 
 ## Progress Bar Methods
 
 ### tick()
-Increment progress by 1:
+Increment progress by 1 and render:
 ```java
 bar.tick();
 ```
 
 ### tick(amount)
-Increment progress by a specific amount:
+Increment progress by a specific amount and render:
 ```java
 bar.tick(10);
 ```
@@ -189,7 +212,7 @@ bar.complete();
 Check if progress is complete:
 ```java
 if (bar.isDone()) {
-    System.out.println("Finished!");
+        System.out.println("Finished!");
 }
 ```
 
@@ -208,37 +231,21 @@ System.out.println(barText);
 
 ## Quick Examples
 
-### File Processing
-```java
-ProgressBarConfiguration config = ProgressBarConfiguration.builder()
-    .format("[blue]:bar[/] :progress/:total files [:elapsed/:remaining]")
-    .build();
-
-ProgressBar bar = Clique.progressBar(files.size(), config);
-
-for (File file : files) {
-    processFile(file);
-    bar.tick();
-    bar.render();
-}
-```
-
 ### Downloading a File
 ```java
 ProgressBarConfiguration config = ProgressBarConfiguration.builder()
-    .length(50)
-    .complete('▓')
-    .incomplete('░')
-    .format("[cyan]↓[/] :bar :percent% | :progress/:total MB")
-    .styleRange(0, 100, "[cyan]:bar[/] :percent% | :progress/:total MB")
-    .build();
+        .length(50)
+        .complete('▓')
+        .incomplete('░')
+        .format("[cyan]↓[/] :bar :percent% | :progress/:total MB")
+        .styleRange(0, 100, "[cyan]:bar[/] :percent% | :progress/:total MB")
+        .build();
 
 ProgressBar bar = Clique.progressBar(totalMB, config);
 
 while (downloading) {
-    int downloaded = getDownloadedMB();
+int downloaded = getDownloadedMB();
     bar.tick(downloaded);
-    bar.render();
     Thread.sleep(100);
 }
 ```
@@ -246,10 +253,10 @@ while (downloading) {
 ### Batch Processing with Status
 ```java
 ProgressBarConfiguration config = ProgressBarConfiguration.builder()
-    .styleRange(0, 50, "[red]:bar[/] :percent% [dim]Processing...[/]")
-    .styleRange(50, 90, "[yellow]:bar[/] :percent% [dim]Finalizing...[/]")
-    .styleRange(90, 100, "[green]:bar[/] :percent% [bold]Complete![/]")
-    .build();
+        .styleRange(0, 50, "[red]:bar[/] :percent% [dim]Processing...[/]")
+        .styleRange(50, 90, "[yellow]:bar[/] :percent% [dim]Finalizing...[/]")
+        .styleRange(90, 100, "[green]:bar[/] :percent% [bold]Complete![/]")
+        .build();
 
 ProgressBar bar = Clique.progressBar(1000, config);
 
@@ -258,7 +265,7 @@ for (int i = 0; i < 1000; i++) {
     bar.tick();
     if (i % 10 == 0) bar.render();
 }
-bar.complete();
+        bar.complete();
 ```
 
 ## See Also


### PR DESCRIPTION
Closes: #36


### Added
- `IterableProgressBar<T>` — wraps a `Collection<T>` and implements `Iterable<T>`, ticking and rendering automatically on each iteration. Single-use; throws `IllegalStateException` if iterated more than once
- New `Clique#progressBar(Collection<T>)` factory overloads:
    - `progressBar(Collection<T>)` — default configuration
    - `progressBar(Collection<T>, ProgressBarConfiguration)` — custom configuration
    - `progressBar(Collection<T>, ProgressBarPreset)` — predefined preset

Decided to skip `EasingConfiguration` overloads because, the progress bar uses the size as its total, hence no need to use an animated tick, since we aren't ticking in batches

### Changed
- `ProgressBar#tick()` now calls `render` on each tick call. 
This was to reduce fricition when calling `tick()` and to keep it consistent with `tickAnimated()`

- `ProgressBarConfiguration#styleRange(min, max)`, max includes the max range as part of the style range. A small QOL improvement 

### Fixed
- `ProgressBar#complete()` no longer throws an exception when called on an already-completed bar
- Passing a null parser no longer causes a NullPointerException during style resolution