### PR TITLE
update tree string building

### DIFF
--- a/Changelogs.md
+++ b/Changelogs.md
@@ -148,9 +148,12 @@ Changes to the SPI module in this release.
 - **`ProgressBarConfiguration#styleRange(min, max)`** — `max` is now inclusive
 - **`StyleResolver`** previously `StyleApplicator` now uses `StyleBuilder` directly for result accumulation, removing the redundant parallel `StringBuilder`
 - **`DefaultStyleBuilder#style()`** now accepts a `StringBuilder` parameter, allowing `stack()` to write in-place and `format()` to use an isolated builder — eliminates unnecessary object allocation and intermediate `toString()` calls
+- **`Tree`** — `buildTree` now uses `StyleBuilder` instead of a raw `StringBuilder`, with guide style resolved eagerly to `AnsiCode[]` at construction time via `ParserUtils.getAnsiCodes()` rather than inlining markup tags into the output string
+- **`TreeConfigurationBuilder#guideStyle()`** no longer wraps the value in `[%s]` markup — raw style strings are now passed through as-is, with ANSI resolution handled downstream by `Tree`
+
 
 ### Fixed
-- **`MarkupPreProcessor`** — pre-parsed ANSI escape sequences in concatenated strings no longer interfere with markup tag detection; ANSI sequences are now tracked and sentineled during pre-processing to prevent `[` in escape codes from corrupting bracket depth tracking in the tokenizer
+- **`MarkupPreProcessor`** — pre-parsed ANSI escape sequences in concatenated strings no longer interfere with markup tag detection; ANSI sequences are now tracked and sentinel during pre-processing to prevent `[` in escape codes from corrupting bracket depth tracking in the tokenizer
 - **`AnsiStringParserImpl#getOriginalString()`** — escaped brackets (`\[`) no longer cause width miscalculations; `postProcess` is now called on the pre-processed string instead of the original input, ensuring `\[` is correctly collapsed to a single character before width is measured
 - **`ProgressBar#complete()`** no longer throws when called on an already-completed bar
 - Passing a null parser into `ProgressBarConfiguration` no longer causes a `NullPointerException` during style resolution

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/Main.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/Main.java
@@ -1,27 +1,31 @@
 package io.github.kusoroadeolu.clique;
 
-import io.github.kusoroadeolu.clique.boxes.BoxType;
+import io.github.kusoroadeolu.clique.config.TreeConfiguration;
+import io.github.kusoroadeolu.clique.tree.Tree;
 
 public class Main {
     public static void main(String[] args) {
-        String redError = Clique.parser().parse("[red, bold]Error:[/]");
-        String greenOk = Clique.parser().parse("[green, bold]Success:[/]");
+        TreeConfiguration config = TreeConfiguration.builder()
+                .guideStyle("*cyan, bold") //Do not add the markup tag borders i.e [*cyan, bold]
+                .build();
 
-// Escaped brackets mixed with pre-parsed ANSI + raw markup
-        Clique.box(BoxType.ROUNDED)
-                .autosize()
-                .content(redError + " Something went wrong \\[not a tag]\n" +
-                        greenOk + " [dim]All good[/] with coords \\[10, 20]" +
-                        "\\[bold] is how you bold things")
-                .render();
+        Tree tree = Clique.tree("[*magenta, bold]clique-lib/", config);
 
-// Frame version
-        Clique.frame()
-                .title("[bold]Docs[/]")
-                .nest(redError + " Use \\[red] for red text")
-                .nest(greenOk + " Use \\[bold] for bold text")
-                .nest("[cyan]Or combine like \\[red, bold][/]")
-                .render();
+        Tree src = tree.add("[*cyan, bold]src/");
+        Tree core = src.add("[cyan]core/");
+        core.add("[green]Parser.java         [dim]✓ 312 lines");
+        core.add("[green]StyleResolver.java  [dim]✓ 198 lines");
+        core.add("[yellow]Renderer.java       [dim]⚠ needs review");
+
+        Tree tests = tree.add("[*cyan, bold]tests/");
+        tests.add("[green, bold]ParserTest.java     [dim]✓ 14/14 pass");
+        tests.add("[red, bold]RendererTest.java   [dim]✗  9/14 pass");
+        tests.add("[dim, strike]TreeTest.java       skipped");
+
+        tree.add("[white]README.md");
+        tree.add("[dim].gitignore");
+
+        tree.print();
 
     }
 }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/boxes/AbstractBox.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/boxes/AbstractBox.java
@@ -90,7 +90,7 @@ public abstract class AbstractBox implements Box {
     WidthAwareList resolveLines(){
         var parser = boxConfiguration.getParser();
         var cellList = boxContent.lines()
-                .map(s -> StringUtils.parseToCell(s, parser))
+                .map(s -> StringUtils.parseToCellIfPresent(s, parser))
                 .toList();
         return new WidthAwareList(cellList);
     }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/TreeConfiguration.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/TreeConfiguration.java
@@ -80,7 +80,7 @@ public class TreeConfiguration {
 
         public TreeConfigurationBuilder guideStyle(String guideStyle){
             Objects.requireNonNull(guideStyle, "Guide style cannot be null");
-            if (!guideStyle.isBlank()) this.guideStyle = "[%s]".formatted(guideStyle);
+            this.guideStyle = guideStyle;
             return this;
         }
 

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/MarkupPreProcessor.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/MarkupPreProcessor.java
@@ -8,9 +8,12 @@ import static io.github.kusoroadeolu.clique.core.utils.StringUtils.nextCharEqual
 @InternalApi(since = "3.2.0")
 public class MarkupPreProcessor {
     private static final char ESCAPE_CHAR = '\\';
-    private static final char OPENING_BRACKET = '[';
-    private static final String PLACEHOLDER = "\uE000";
-    private static final String ANSI_SENTINEL = "\uFFFF";
+    private static final String ESCAPE_PLACEHOLDER = "\uE000";
+
+
+    private static final String ANSI_SENTINEL = "]\uFFFF";
+    //uFFFF is an invalid UNICODE char meaning it can never appear in any valid strings hence, why it's our placeholder here. Also, we use the ] to close the ansi code, so other tags after it are not treated as invalid/nested tags by the parser
+
 
     public String preProcess(String input) {
         if (input == null || input.isEmpty()) return input;
@@ -24,7 +27,7 @@ public class MarkupPreProcessor {
         while (i < sb.length()) {
             char c = sb.charAt(i);
 
-            if (c == ESC && nextCharEquals(sb, i + 1, OPENING_BRACKET)) {
+            if (c == ESC && nextCharEquals(sb, i + 1, LBRACKET)) {
                 inAnsi = true;
                 processed.append(c);
                 processed.append(sb.charAt(i + 1));
@@ -48,8 +51,7 @@ public class MarkupPreProcessor {
 
     public String postProcess(String input) {
         if (input == null || input.isEmpty()) return input;
-        return input
-                .replace(PLACEHOLDER, String.valueOf(OPENING_BRACKET))
+        return input.replace(ESCAPE_PLACEHOLDER, String.valueOf(LBRACKET))
                 .replace(ANSI_SENTINEL, EMPTY);
     }
 
@@ -59,8 +61,8 @@ public class MarkupPreProcessor {
 
         for (int i = 0; i < len; i++) {
             final char c = input.charAt(i);
-            if (c == ESCAPE_CHAR && (i + 1) < len && input.charAt(i + 1) == OPENING_BRACKET) {
-                sb.append(PLACEHOLDER);
+            if (c == ESCAPE_CHAR && (i + 1) < len && input.charAt(i + 1) == LBRACKET) {
+                sb.append(ESCAPE_PLACEHOLDER);
                 i++;
             } else {
                 sb.append(c);

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/ParserUtils.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/ParserUtils.java
@@ -12,6 +12,7 @@ import java.util.List;
 @InternalApi(since = "3.2.0")
 public class ParserUtils {
     public static List<AnsiCode> getAnsiCodes(String string) {
+        if (string.isBlank()) return List.of();
         var parser = (AnsiStringParserImpl) AnsiStringParser.DEFAULT;
         return Arrays.stream(string.split(parser.parserConfiguration().getDelimiter()))
                 .map(s -> StyleMaps.findStyle(s.trim())

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/Constants.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/Constants.java
@@ -11,6 +11,8 @@ public class Constants {
     public static final int ZERO = 0;
     public static final char ANSI_END = 'm';
     public static final char ESC = '\u001b';
+    public static final char LBRACKET = '[';
+    public static final char RBRACKET = ']';
 
     //FOR ANSI DETECTOR
     public static final String TERM = "TERM";

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/StringUtils.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/StringUtils.java
@@ -14,12 +14,12 @@ public final class StringUtils {
         sb.setLength(ZERO);
     }
 
-    public static Cell parseToCell(String text, AnsiStringParser parser) {
+    public static Cell parseToCellIfPresent(String text, AnsiStringParser parser) {
         if (parser != null) return new Cell(parser.getOriginalString(text), parser.parse(text));
         else return new Cell(text, text);
     }
 
-    public static String parseString(String text, AnsiStringParser parser) {
+    public static String parseIfPresent(String text, AnsiStringParser parser) {
         if (parser != null) return parser.parse(text);
         else return text;
     }
@@ -30,21 +30,17 @@ public final class StringUtils {
         var clean = new StringBuilder();
 
         while (i < styled.length()) {
-            char c;
-            if ((c = styled.charAt(i)) == ESC && nextCharEquals(styled, i + 1, '[')) {
+            char c = styled.charAt(i);
+            if (c == ESC && nextCharEquals(styled, i + 1, LBRACKET)) {
                 inAnsi = true;
                 i++;
-                continue;
             } else if (inAnsi && (c = styled.charAt(i)) == ANSI_END) {
                 inAnsi = false;
                 i++;
-                continue;
-            }
-
-            if (!inAnsi){
+            }else if (!inAnsi){
                 clean.append(c);
+                i++;
             }
-            i++;
         }
 
         return clean.toString();

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/frame/DefaultFrame.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/frame/DefaultFrame.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 import static io.github.kusoroadeolu.clique.ansi.StyleCode.RESET;
 import static io.github.kusoroadeolu.clique.core.utils.BoxUtils.applyAnsiToBorders;
 import static io.github.kusoroadeolu.clique.core.utils.Constants.*;
-import static io.github.kusoroadeolu.clique.core.utils.StringUtils.parseToCell;
+import static io.github.kusoroadeolu.clique.core.utils.StringUtils.parseToCellIfPresent;
 
 @InternalApi(since = "3.2.0")
 public class DefaultFrame implements  Frame {
@@ -112,7 +112,7 @@ public class DefaultFrame implements  Frame {
         if (configuration.getParser() != null && !title.isEmpty()) appendedTitle = title + RESET; //Add a reset flag to prevent title colors from bleeding
 
 
-        var parsedTitle = parseToCell(appendedTitle, configuration.getParser());
+        var parsedTitle = parseToCellIfPresent(appendedTitle, configuration.getParser());
         int titleWidth = parsedTitle.width() + 2;
         int nodesMaxWidth = findNodesMaxWidth(); //Max content width
 

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/frame/FrameNode.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/frame/FrameNode.java
@@ -9,7 +9,7 @@ import io.github.kusoroadeolu.clique.parser.AnsiStringParser;
 import java.util.List;
 
 import static io.github.kusoroadeolu.clique.core.utils.Constants.ZERO;
-import static io.github.kusoroadeolu.clique.core.utils.StringUtils.parseToCell;
+import static io.github.kusoroadeolu.clique.core.utils.StringUtils.parseToCellIfPresent;
 import static io.github.kusoroadeolu.clique.parser.AnsiStringParser.DEFAULT;
 
 @InternalApi(since = "3.2.0")
@@ -27,12 +27,12 @@ sealed interface FrameNode permits FrameNode.StringNode, FrameNode.ComponentNode
     }
 
     static List<Cell> splitComponentLines(String str){
-        return str.lines().map(s -> parseToCell(s, DEFAULT)).toList(); //Original to styled string for components, we actually need to parse here with a default parser
+        return str.lines().map(s -> parseToCellIfPresent(s, DEFAULT)).toList(); //Original to styled string for components, we actually need to parse here with a default parser
     }
 
     //For raw strings, we need to handle the case in which the string has markup, however for components, when we call the get method, they apply their markup so it's good
     static List<Cell> splitLines(String str, AnsiStringParser parser){
-        return str.lines().map(s -> parseToCell(s, parser)).toList();
+        return str.lines().map(s -> parseToCellIfPresent(s, parser)).toList();
     }
 
 

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/indent/DefaultIndenter.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/indent/DefaultIndenter.java
@@ -123,7 +123,7 @@ public class DefaultIndenter implements Indenter {
     }
 
     private String parseString(String str) {
-        return StringUtils.parseString(str, this.configuration.getParser());
+        return StringUtils.parseIfPresent(str, this.configuration.getParser());
     }
 
     public Indenter resetLevel() {
@@ -136,7 +136,7 @@ public class DefaultIndenter implements Indenter {
         if (object == null || getClass() != object.getClass()) return false;
 
         DefaultIndenter indenter = (DefaultIndenter) object;
-        return currentLevel == indenter.currentLevel && indents.equals(indenter.indents) && currentFlag.equals(indenter.currentFlag) && sb.equals(indenter.sb) && configuration.equals(indenter.configuration);
+        return currentLevel == indenter.currentLevel && indents.equals(indenter.indents) && currentFlag.equals(indenter.currentFlag) && (sb.compareTo(indenter.sb) == 0) && configuration.equals(indenter.configuration);
     }
 
     public int hashCode() {
@@ -149,7 +149,7 @@ public class DefaultIndenter implements Indenter {
                 "indents=" + indents +
                 ", currentFlag='" + currentFlag + '\'' +
                 ", currentLevel=" + currentLevel +
-                ", sb=" + sb +
+                ", text=" + sb +
                 ", configuration=" + configuration +
                 ']';
     }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImpl.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/AnsiStringParserImpl.java
@@ -38,7 +38,9 @@ public record AnsiStringParserImpl(ParserConfiguration parserConfiguration) impl
         String processed = PROCESSOR.preProcess(tokenedString);
         ParseResult result = this.getParseResult(processed);
 
-        if (!result.isPresent()) return stripAnsi(PROCESSOR.postProcess(processed));
+        if (!result.isPresent()) {
+            return stripAnsi(PROCESSOR.postProcess(processed));
+        }
 
         final List<ParseToken> tokens = result.tokens();
         final StringBuilder sb = new StringBuilder(processed.length());
@@ -48,6 +50,7 @@ public record AnsiStringParserImpl(ParserConfiguration parserConfiguration) impl
             sb.append(processed, cursor, token.start());
             cursor = token.end() + 1;
         }
+
         sb.append(processed, cursor, processed.length());
 
         return stripAnsi(PROCESSOR.postProcess(sb.toString()));

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/progressbar/ProgressBar.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/progressbar/ProgressBar.java
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit;
 
 import static io.github.kusoroadeolu.clique.core.utils.Constants.BLANK;
 import static io.github.kusoroadeolu.clique.core.utils.Constants.ZERO;
-import static io.github.kusoroadeolu.clique.core.utils.StringUtils.parseString;
+import static io.github.kusoroadeolu.clique.core.utils.StringUtils.parseIfPresent;
 
 /**
  * @since 3.0.0
@@ -178,7 +178,7 @@ public class ProgressBar implements Bordered {
         var remaining = interval(remainingTime());
         format = format.replace(":remaining", remaining);
 
-        return parseString(format, this.progressBarConfiguration.parser());
+        return parseIfPresent(format, this.progressBarConfiguration.parser());
     }
 
 

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/tables/AbstractTable.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/tables/AbstractTable.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-import static io.github.kusoroadeolu.clique.core.utils.StringUtils.parseToCell;
+import static io.github.kusoroadeolu.clique.core.utils.StringUtils.parseToCellIfPresent;
 import static io.github.kusoroadeolu.clique.core.utils.TableUtils.*;
 import static java.util.Objects.isNull;
 
@@ -52,7 +52,7 @@ public abstract class AbstractTable implements Table {
                 row = handleNulls(row, this.tableConfiguration.getNullReplacement());
             }
 
-            final Cell c = parseToCell(row, this.tableConfiguration.getParser());
+            final Cell c = parseToCellIfPresent(row, this.tableConfiguration.getParser());
             rowList.add(c);
             final WidthAwareList colList = this.columns.get(i);
             colList.add(c);
@@ -85,7 +85,7 @@ public abstract class AbstractTable implements Table {
 
         final WidthAwareList rl = this.rows.get(row);
         final WidthAwareList cl = this.columns.get(col);
-        final Cell c = parseToCell(text, this.tableConfiguration.getParser());
+        final Cell c = parseToCellIfPresent(text, this.tableConfiguration.getParser());
         rl.update(col, c);
         cl.update(row, c);
         nullCachedString();
@@ -145,7 +145,7 @@ public abstract class AbstractTable implements Table {
             for (int i = 0; i < headers.length; i++) {
                 String header = headers[i];
                 header = handleNulls(header, table.tableConfiguration.getNullReplacement());
-                final var cell = parseToCell(header, table.tableConfiguration.getParser());
+                final var cell = parseToCellIfPresent(header, table.tableConfiguration.getParser());
                 rowList.add(cell);
                 final var colList = new WidthAwareList(); //To keep track of all values in this column
                 colList.add(cell);

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/tree/Tree.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/tree/Tree.java
@@ -2,6 +2,11 @@ package io.github.kusoroadeolu.clique.tree;
 
 import io.github.kusoroadeolu.clique.config.TreeConfiguration;
 import io.github.kusoroadeolu.clique.core.display.Borderless;
+import io.github.kusoroadeolu.clique.core.parser.ParserUtils;
+import io.github.kusoroadeolu.clique.core.utils.StringUtils;
+import io.github.kusoroadeolu.clique.spi.AnsiCode;
+import io.github.kusoroadeolu.clique.style.DefaultStyleBuilder;
+import io.github.kusoroadeolu.clique.style.StyleBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +23,7 @@ public class Tree implements Borderless {
     static final String END_CONNECTOR = "└─ ";
     static final String SPACE = "   ";
     static final String CONNECTING_LINE = "│  ";
-    private static final String RESET = "[/]";
+    private final AnsiCode[] guideStyle;
     private Tree parent;
 
     public Tree(String label) {
@@ -36,6 +41,7 @@ public class Tree implements Borderless {
         this.children = new ArrayList<>();
         this.treeConfiguration = treeConfiguration;
         this.parent = parent;
+        this.guideStyle = ParserUtils.getAnsiCodes(treeConfiguration.getGuideStyle()).toArray(AnsiCode[]::new);
     }
 
     public Tree add(String label) {
@@ -57,15 +63,11 @@ public class Tree implements Borderless {
         return parent;
     }
 
-    private void buildTree(Tree node, String prefix, boolean isLast, StringBuilder sb) {
+    private void buildTree(Tree node, String prefix, boolean isLast, StyleBuilder sb) {
         String connector = isLast ? END_CONNECTOR : CONNECTOR;
-        String guideStyle = treeConfiguration.getGuideStyle();
-        sb.append(guideStyle)
-                .append(prefix)
+        sb.stack(prefix, this.guideStyle)
                 .append(connector)
-                .append(RESET)
                 .append(node.label)
-                .append(RESET)
                 .append(NEWLINE);
 
         var childPrefix = prefix + (isLast ? SPACE : CONNECTING_LINE);
@@ -88,16 +90,14 @@ public class Tree implements Borderless {
 
     @Override
     public String get() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(label)
-                .append(RESET)
-                .append(NEWLINE);
+        var sb = new DefaultStyleBuilder();
+        sb.append(label).append(NEWLINE);
         for (int i = 0; i < children.size(); i++) {
             buildTree(children.get(i), EMPTY, i == children.size() - 1, sb);
         }
 
         var parser = treeConfiguration.getParser();
-        return parser != null ? parser.parse(sb.toString()) : sb.toString();
+        return StringUtils.parseIfPresent(sb.get(), parser);
     }
 
     //For Tests

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -125,8 +125,8 @@ TreeConfiguration config = TreeConfiguration.builder()
 
 ```java
 TreeConfiguration config = TreeConfiguration.builder()
-    .guideStyle("*cyan, bold") //Do not add the markup tag borders i.e [*cyan, bold]
-    .build();
+        .guideStyle("*cyan, bold") //Do not add the markup tag borders i.e [*cyan, bold]
+        .build();
 
 Tree tree = Clique.tree("[*magenta, bold]clique-lib/", config);
 


### PR DESCRIPTION
## Changed
- **`Tree`** -> `buildTree` now uses `StyleBuilder` instead of a raw `StringBuilder`, with guide style resolved eagerly to `AnsiCode[]` at construction time via `ParserUtils.getAnsiCodes()` rather than inlining markup tags into the output string
- **`TreeConfigurationBuilder#guideStyle()`** no longer wraps the value in `[%s]` markup -> raw style strings are now passed through as-is, with ANSI resolution handled downstream by `Tree`