### PR TITLE
refactor: remove deprecated immutable builder methods

### DIFF
--- a/Changelogs.md
+++ b/Changelogs.md
@@ -190,6 +190,9 @@ _(no changes noted)_
 ## Clique [4.0.0] - [UNRELEASED]
 ### Added 
 - `AnsiCode` varargs and `String` overloads in `Clique` facade in place of `BorderSpec` types. These overloads provide uniform styling across each component's borders, removing the use of per edge control.
+- `flagColor()` method to `IndenterConfiguration` which applies a default color to all flags with `AnsiCode...` and `String` overloads. Markup applied on flags still takes precedence
+- `connectorColor()` method to `TreeConfiguration`with `AnsiCode...` and `String` overloads
+
 
 ### Fixed
 - An off by one error in `Frame` when a title wider than the frame's content was aligned left or right.
@@ -202,6 +205,7 @@ _(no changes noted)_
 - `BorderStyle` and `BorderSpec` types entirely, along with their usages across `BoxConfiguration`, `FrameConfiguration`, and `TableConfiguration`
 - `fromBorderStyle(BorderSpec)` factory methods from `BoxConfiguration`, `FrameConfiguration`, and `TableConfiguration`
 - `getBorderStyle()` getters and `borderStyle(BorderSpec)` builder methods from all three configuration classes
+- Deprecated `immutableBuilder()` methods in configuration classes
 
 ### Updated
 - `Box` and `BoxConfiguration` `equals()` and `hashcode()` contracts

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/BoxConfiguration.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/BoxConfiguration.java
@@ -37,7 +37,6 @@ public class BoxConfiguration {
     }
 
 
-
     public int getPadding() {
         return this.padding;
     }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/EasingConfiguration.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/EasingConfiguration.java
@@ -47,14 +47,6 @@ public class EasingConfiguration {
         return new EasingConfigurationBuilder();
     }
 
-    /**
-     * @deprecated As of 3.1.3, use {@link EasingConfiguration#builder()} instead. This will be removed in a future release.
-     * */
-    @Deprecated(since = "3.1.3", forRemoval = true)
-    public static EasingConfigurationBuilder immutableBuilder() {
-        return builder();
-    }
-
     public EasingFunction getFunction() {
         return function;
     }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/FrameConfiguration.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/FrameConfiguration.java
@@ -1,6 +1,5 @@
 package io.github.kusoroadeolu.clique.config;
 
-import io.github.kusoroadeolu.clique.Clique;
 import io.github.kusoroadeolu.clique.core.documentation.Stable;
 import io.github.kusoroadeolu.clique.core.parser.ParserUtils;
 import io.github.kusoroadeolu.clique.parser.AnsiStringParser;
@@ -34,14 +33,6 @@ public class FrameConfiguration {
 
     public static FrameConfigurationBuilder builder() {
         return new FrameConfigurationBuilder();
-    }
-
-    /**
-     * @deprecated As of 3.1.3, use {@link FrameConfiguration#builder()} instead. This will be removed in a future release.
-     */
-    @Deprecated(since = "3.1.3", forRemoval = true)
-    public static FrameConfigurationBuilder immutableBuilder() {
-        return builder();
     }
 
     public int getPadding() {

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/IndenterConfiguration.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/IndenterConfiguration.java
@@ -40,14 +40,6 @@ public class IndenterConfiguration {
         return new IndenterConfigurationBuilder();
     }
 
-    /**
-     * @deprecated As of 3.1.3, use {@link IndenterConfiguration#builder()} instead. This will be removed in a future release.
-     * */
-    @Deprecated(since = "3.1.3", forRemoval = true)
-    public static IndenterConfigurationBuilder immutableBuilder() {
-        return builder();
-    }
-
     @Override
     public String toString() {
         return "IndenterConfiguration[" +

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/ParserConfiguration.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/ParserConfiguration.java
@@ -31,14 +31,6 @@ public class ParserConfiguration {
         return new ParserConfigurationBuilder();
     }
 
-    /**
-     * @deprecated As of 3.2.0, use {@link ParserConfiguration#builder()} instead. This will be removed in a future release.
-     * */
-    @Deprecated(since = "3.2.0", forRemoval = true)
-    public static ParserConfigurationBuilder immutableBuilder() {
-        return builder();
-    }
-
     public boolean getEnableStrictParsing() {
         return enableStrictParsing;
     }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/ProgressBarConfiguration.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/ProgressBarConfiguration.java
@@ -41,14 +41,6 @@ public class ProgressBarConfiguration {
         return new ProgressBarConfigurationBuilder();
     }
 
-    /**
-     * @deprecated As of 3.2.0, use {@link ProgressBarConfiguration#builder()} instead. This will be removed in a future release.
-     * */
-    @Deprecated(since = "3.2.0", forRemoval = true)
-    public static ProgressBarConfigurationBuilder immutableBuilder() {
-        return builder();
-    }
-
     @Stable(since = "3.2.1")
     public static ProgressBarConfigurationBuilder fromPreset(ProgressBarPreset preset) {
         Objects.requireNonNull(preset, "Preset cannot be null");

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/TableConfiguration.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/TableConfiguration.java
@@ -41,14 +41,6 @@ public class TableConfiguration {
         return new TableConfigurationBuilder();
     }
 
-    /**
-     * @deprecated As of 3.1.3, use {@link TableConfiguration#builder()} instead. This will be removed in a future release.
-     */
-    @Deprecated(since = "3.1.3", forRemoval = true)
-    public static TableConfigurationBuilder immutableBuilder() {
-        return builder();
-    }
-
     public int getPadding() {
         return this.padding;
     }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/TreeConfiguration.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/TreeConfiguration.java
@@ -30,14 +30,6 @@ public class TreeConfiguration {
         return new TreeConfigurationBuilder();
     }
 
-    /**
-     * @deprecated As of 3.1.3, use {@link TreeConfiguration#builder()} instead. This will be removed in a future release.
-     * */
-    @Deprecated(since = "3.1.3", forRemoval = true)
-    public static TreeConfigurationBuilder immutableBuilder() {
-        return builder();
-    }
-
     public AnsiStringParser getParser() {
         return parser;
     }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/ParserUtils.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/ParserUtils.java
@@ -6,7 +6,6 @@ import io.github.kusoroadeolu.clique.parser.AnsiStringParser;
 import io.github.kusoroadeolu.clique.spi.AnsiCode;
 
 import java.util.Arrays;
-import java.util.List;
 
 @InternalApi(since = "3.2.0")
 public class ParserUtils {

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/AnsiDetector.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/AnsiDetector.java
@@ -9,11 +9,9 @@ import static io.github.kusoroadeolu.clique.core.utils.Constants.*;
 @InternalApi(since = "3.2.0")
 public class AnsiDetector {
 
-    private AnsiDetector() {
-        throw new AssertionError("Cannot instantiate this");
-    }
+    private AnsiDetector() {}
 
-    private final static AtomicBoolean ANSI_ENABLED = new AtomicBoolean(autoDetect());
+    private static final AtomicBoolean ANSI_ENABLED = new AtomicBoolean(autoDetect());
 
 
     //FOR TESTS

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/BoxUtils.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/BoxUtils.java
@@ -19,8 +19,9 @@ import static io.github.kusoroadeolu.clique.style.StyleBuilder.formatAndReset;
 @InternalApi(since = "3.2.0")
 public class BoxUtils {
 
-    private final static String RESET = StyleCode.RESET.toString();
+    private BoxUtils(){}
 
+    private final static String RESET = StyleCode.RESET.toString();
 
     public static void alignText(StringBuilder sb, int idx, TextAlign textAlign, String spaces, List<Cell> wordWrap, String vLine, int padding) {
         final Cell cell = wordWrap.get(idx);

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/Constants.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/Constants.java
@@ -29,7 +29,5 @@ public class Constants {
     public static final String WT_SESSION = "WT_SESSION";
     public static final String FORCE_COLOR = "FORCE_COLOR";
 
-    private Constants() {
-        throw new AssertionError("cannot instantiate this");
-    }
+    private Constants() {}
 }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/StringUtils.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/StringUtils.java
@@ -10,6 +10,8 @@ import static io.github.kusoroadeolu.clique.core.utils.Constants.*;
 @InternalApi(since = "3.2.0")
 public final class StringUtils {
 
+    private StringUtils(){}
+
     public static void clearStringBuilder(StringBuilder sb) {
         sb.setLength(ZERO);
     }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/TableUtils.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/utils/TableUtils.java
@@ -11,6 +11,7 @@ import static io.github.kusoroadeolu.clique.core.utils.Constants.BLANK;
 
 @InternalApi(since = "3.2.0")
 public class TableUtils {
+    private TableUtils(){}
 
     public static String align(CellAlign align, StringBuilder sb, int offset, String cell, String vLine) {
 


### PR DESCRIPTION
### Removed
- Deprecated `immutableBuilder()` methods in configuration classes
