### PR TITLE
Feat/locally scoped styles

### DIFF
--- a/Changelogs.md
+++ b/Changelogs.md
@@ -118,7 +118,7 @@ _(no changes noted)_
 - `Clique` facade overloads now accept `BorderSpec` instead of a `BorderStyle`
 - `builder()` is now the standard entry point for all configuration classes
 - Parser escape syntax replaced — `[content[/]]` is removed in favor of `\[` (e.g. `\[red]` renders as `[red]`)
-- `enableAutoCloseTags` now correctly described as style leak prevention — resets styles when a new tag is encountered rather than forgiving malformed tags
+- `enableAutoReset` now correctly described as style leak prevention — resets styles when a new tag is encountered rather than forgiving malformed tags
 - `enableStrictParsing` no longer throws on unrecognized or structurally unusual brackets — only throws `UnidentifiedStyleException` when a valid tag contains an unrecognized style
 
 ### Fixed
@@ -185,14 +185,12 @@ _(no changes noted)_
 _(no changes noted)_
 
 
-# Changelog
-
 ## Clique [4.0.0] - [UNRELEASED]
-### Added 
+### Added
 - `AnsiCode` varargs and `String` overloads in `Clique` facade in place of `BorderSpec` types. These overloads provide uniform styling across each component's borders, removing the use of per edge control.
 - `flagColor()` method to `IndenterConfiguration` which applies a default color to all flags with `AnsiCode...` and `String` overloads. Markup applied on flags still takes precedence
-- `connectorColor()` method to `TreeConfiguration`with `AnsiCode...` and `String` overloads
-
+- `connectorColor()` method to `TreeConfiguration` with `AnsiCode...` and `String` overloads
+- `StyleContext` support in `ParserConfiguration` via `styleContext(StyleContext)` and `addStyle(String, AnsiCode)` builder methods, allowing custom styles scoped to a specific parser instance
 
 ### Fixed
 - An off by one error in `Frame` when a title wider than the frame's content was aligned left or right.
@@ -213,6 +211,7 @@ _(no changes noted)_
 - `Clique#table` overloads to return `PendingTable` interface, in place of `TableDimensionBuilder`
 - `Tree#parent` returns an `Optional<Tree>` type instead of a `Tree` type.
 - `AnsiStringParser` to `MarkupParser`
-- 
-## clique-spi [2.0.0] - 2026-04-03
+- `enableAutoCloseTags()` renamed to `enableAutoReset()` in `ParserConfiguration` to better reflect its behavior of resetting ANSI codes after each styled segment
+
+## clique-spi [2.0.0] - [UNRELEASED]
 - `AnsiCode#toString()` contract renamed to `AnsiCode#ansiSequence()`

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/ansi/CompositeColor.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/ansi/CompositeColor.java
@@ -1,0 +1,27 @@
+package io.github.kusoroadeolu.clique.ansi;
+
+import io.github.kusoroadeolu.clique.spi.AnsiCode;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public class CompositeColor implements AnsiCode {
+    private final String ansiSequence;
+
+    public CompositeColor(AnsiCode... codes) {
+        StringBuilder sb = new StringBuilder();
+        Arrays.stream(codes).forEach(c -> sb.append(c.ansiSequence()));
+        ansiSequence = sb.toString();
+    }
+
+    public CompositeColor(Collection<AnsiCode> codes) {
+        StringBuilder sb = new StringBuilder();
+        codes.forEach(c -> sb.append(c.ansiSequence()));
+        ansiSequence = sb.toString();
+    }
+
+    @Override
+    public String ansiSequence() {
+        return ansiSequence;
+    }
+}

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/IndenterConfiguration.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/IndenterConfiguration.java
@@ -81,7 +81,7 @@ public class IndenterConfiguration {
 
     public static class IndenterConfigurationBuilder {
         private int indentLevel = 1;
-        private MarkupParser parser = new MarkupParser(ParserConfiguration.builder().enableAutoCloseTags().build());
+        private MarkupParser parser = new MarkupParser(ParserConfiguration.builder().enableAutoReset().build());
         private String defaultFlag = BLANK;
         private AnsiCode[] flagColor = {};
 

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/ParserConfiguration.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/ParserConfiguration.java
@@ -1,6 +1,8 @@
 package io.github.kusoroadeolu.clique.config;
 
 import io.github.kusoroadeolu.clique.core.documentation.Stable;
+import io.github.kusoroadeolu.clique.parser.StyleContext;
+import io.github.kusoroadeolu.clique.spi.AnsiCode;
 
 import java.util.Objects;
 
@@ -14,6 +16,7 @@ public class ParserConfiguration {
     private final String delimiter;
     private final boolean enableStrictParsing;
     private final boolean enableAutoCloseTags;
+    private final StyleContext styleContext;
 
 
     //Default Configuration
@@ -25,6 +28,7 @@ public class ParserConfiguration {
         this.delimiter = builder.delimiter;
         this.enableStrictParsing = builder.enableStrictParsing;
         this.enableAutoCloseTags = builder.enableAutoCloseTags;
+        this.styleContext = builder.context;
     }
 
     public static ParserConfigurationBuilder builder() {
@@ -41,6 +45,10 @@ public class ParserConfiguration {
 
     public String getDelimiter() {
         return delimiter;
+    }
+
+    public StyleContext getStyleContext() {
+        return styleContext;
     }
 
     @Override
@@ -69,6 +77,8 @@ public class ParserConfiguration {
         private String delimiter = String.valueOf(',');
         private boolean enableStrictParsing = false;
         private boolean enableAutoCloseTags = false;
+        private final StyleContext.StyleContextBuilder styleContextBuilder = StyleContext.builder();
+        private StyleContext context;
 
         public ParserConfigurationBuilder enableAutoCloseTags() {
             this.enableAutoCloseTags = true;
@@ -81,11 +91,22 @@ public class ParserConfiguration {
         }
 
         public ParserConfigurationBuilder delimiter(char delimiter) {
-            this.delimiter = String.valueOf(delimiter);
+            this.delimiter = Character.toString(delimiter);
+            return this;
+        }
+
+        public ParserConfigurationBuilder addStyle(String markup, AnsiCode code){
+            styleContextBuilder.add(markup, code);
+            return this;
+        }
+
+        public ParserConfigurationBuilder styleContext(StyleContext styleContext){
+            this.styleContextBuilder.add(styleContext);
             return this;
         }
 
         public ParserConfiguration build() {
+            this.context = styleContextBuilder.build();
             return new ParserConfiguration(this);
         }
     }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/ParserConfiguration.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/config/ParserConfiguration.java
@@ -15,7 +15,7 @@ public class ParserConfiguration {
 
     private final String delimiter;
     private final boolean enableStrictParsing;
-    private final boolean enableAutoCloseTags;
+    private final boolean enableAutoReset;
     private final StyleContext styleContext;
 
 
@@ -27,7 +27,7 @@ public class ParserConfiguration {
     private ParserConfiguration(ParserConfigurationBuilder builder) {
         this.delimiter = builder.delimiter;
         this.enableStrictParsing = builder.enableStrictParsing;
-        this.enableAutoCloseTags = builder.enableAutoCloseTags;
+        this.enableAutoReset = builder.enableAutoReset;
         this.styleContext = builder.context;
     }
 
@@ -39,8 +39,8 @@ public class ParserConfiguration {
         return enableStrictParsing;
     }
 
-    public boolean getEnableAutoCloseTags() {
-        return enableAutoCloseTags;
+    public boolean getEnableAutoReset() {
+        return enableAutoReset;
     }
 
     public String getDelimiter() {
@@ -56,12 +56,12 @@ public class ParserConfiguration {
         if (object == null || getClass() != object.getClass()) return false;
 
         ParserConfiguration that = (ParserConfiguration) object;
-        return enableStrictParsing == that.enableStrictParsing && enableAutoCloseTags == that.enableAutoCloseTags && delimiter.equals(that.delimiter);
+        return enableStrictParsing == that.enableStrictParsing && enableAutoReset == that.enableAutoReset && delimiter.equals(that.delimiter);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(enableAutoCloseTags, enableStrictParsing, delimiter);
+        return Objects.hash(enableAutoReset, enableStrictParsing, delimiter);
     }
 
     @Override
@@ -69,19 +69,19 @@ public class ParserConfiguration {
         return "ParserConfiguration[" +
                 "delimiter='" + delimiter + '\'' +
                 ", enableStrictParsing=" + enableStrictParsing +
-                ", enableAutoCloseTags=" + enableAutoCloseTags +
+                ", enableAutoReset=" + enableAutoReset +
                 ']';
     }
 
     public static class ParserConfigurationBuilder {
         private String delimiter = String.valueOf(',');
         private boolean enableStrictParsing = false;
-        private boolean enableAutoCloseTags = false;
+        private boolean enableAutoReset = false;
         private final StyleContext.StyleContextBuilder styleContextBuilder = StyleContext.builder();
-        private StyleContext context;
+        private StyleContext context = StyleContext.NONE;
 
-        public ParserConfigurationBuilder enableAutoCloseTags() {
-            this.enableAutoCloseTags = true;
+        public ParserConfigurationBuilder enableAutoReset() {
+            this.enableAutoReset = true;
             return this;
         }
 

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/GlobalStyleRegistry.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/GlobalStyleRegistry.java
@@ -13,11 +13,11 @@ public class GlobalStyleRegistry {
     }
 
     public static void registerStyle(String style, AnsiCode code) {
-        StyleMaps.CUSTOM_STYLE_CODES.put(style, code);
+        PredefinedStyleContext.CUSTOM_STYLE_CODES.put(style, code);
     }
 
     public static void registerStyles(Map<String, AnsiCode> codes) {
-        StyleMaps.CUSTOM_STYLE_CODES.putAll(codes);
+        PredefinedStyleContext.CUSTOM_STYLE_CODES.putAll(codes);
     }
 
 

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/ParserUtils.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/ParserUtils.java
@@ -7,16 +7,22 @@ import io.github.kusoroadeolu.clique.spi.AnsiCode;
 
 import java.util.Arrays;
 
+import static io.github.kusoroadeolu.clique.core.parser.PredefinedStyleContext.findStyle;
+
 @InternalApi(since = "3.2.0")
 public class ParserUtils {
+    private static final AnsiCode[] NONE = new AnsiCode[0];
+
+    private ParserUtils(){}
+
     public static AnsiCode[] getAnsiCodes(String string) {
-        return getAnsiCodes(string, (MarkupParser) MarkupParser.DEFAULT);
+        return getAnsiCodes(string, MarkupParser.DEFAULT);
     }
 
     public static AnsiCode[] getAnsiCodes(String string, MarkupParser parser) {
-        if (string.isBlank()) return new AnsiCode[0];
+        if (string.isBlank()) return NONE;
         return Arrays.stream(string.split(parser.parserConfiguration().getDelimiter()))
-                .map(s -> StyleMaps.findStyle(s.trim())
+                .map(s -> findStyle(s.trim(), parser.parserConfiguration().getStyleContext())
                         .orElseThrow(() -> new UnidentifiedStyleException("Failed to find ansi code mapped to style: %s".formatted(s)))
                 )
                 .toArray(AnsiCode[]::new);

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/PredefinedStyleContext.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/PredefinedStyleContext.java
@@ -4,6 +4,7 @@ import io.github.kusoroadeolu.clique.ansi.BackgroundCode;
 import io.github.kusoroadeolu.clique.ansi.ColorCode;
 import io.github.kusoroadeolu.clique.ansi.StyleCode;
 import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
+import io.github.kusoroadeolu.clique.parser.StyleContext;
 import io.github.kusoroadeolu.clique.spi.AnsiCode;
 
 import java.util.Map;
@@ -12,38 +13,39 @@ import java.util.concurrent.ConcurrentHashMap;
 
 //A simple class which holds the maps of the syntax
 @InternalApi(since = "3.2.0")
-public final class StyleMaps {
+public final class PredefinedStyleContext {
 
     /**
      * A static, unmodifiable map that associates lowercase color names (keys)
      * with their corresponding ColorCode enum constants (values).
      */
-    static final Map<String, ColorCode> COLOR_CODES = Map.ofEntries(
-            // Standard Colors
-            Map.entry("black", ColorCode.BLACK),
-            Map.entry("red", ColorCode.RED),
-            Map.entry("green", ColorCode.GREEN),
-            Map.entry("yellow", ColorCode.YELLOW),
-            Map.entry("blue", ColorCode.BLUE),
-            Map.entry("magenta", ColorCode.MAGENTA),
-            Map.entry("cyan", ColorCode.CYAN),
-            Map.entry("white", ColorCode.WHITE),
+    static final StyleContext COLOR_CODES = StyleContext.from(
+            Map.ofEntries(
+                    // Standard Colors
+                    Map.entry("black", ColorCode.BLACK),
+                    Map.entry("red", ColorCode.RED),
+                    Map.entry("green", ColorCode.GREEN),
+                    Map.entry("yellow", ColorCode.YELLOW),
+                    Map.entry("blue", ColorCode.BLUE),
+                    Map.entry("magenta", ColorCode.MAGENTA),
+                    Map.entry("cyan", ColorCode.CYAN),
+                    Map.entry("white", ColorCode.WHITE),
 
-            // Bright Colors
-            Map.entry("*black", ColorCode.BRIGHT_BLACK),
-            Map.entry("*red", ColorCode.BRIGHT_RED),
-            Map.entry("*green", ColorCode.BRIGHT_GREEN),
-            Map.entry("*yellow", ColorCode.BRIGHT_YELLOW),
-            Map.entry("*blue", ColorCode.BRIGHT_BLUE), // Kept your original example format for bright colors
-            Map.entry("*magenta", ColorCode.BRIGHT_MAGENTA),
-            Map.entry("*cyan", ColorCode.BRIGHT_CYAN),
-            Map.entry("*white", ColorCode.BRIGHT_WHITE)
-    );
+                    // Bright Colors
+                    Map.entry("*black", ColorCode.BRIGHT_BLACK),
+                    Map.entry("*red", ColorCode.BRIGHT_RED),
+                    Map.entry("*green", ColorCode.BRIGHT_GREEN),
+                    Map.entry("*yellow", ColorCode.BRIGHT_YELLOW),
+                    Map.entry("*blue", ColorCode.BRIGHT_BLUE), // Kept your original example format for bright colors
+                    Map.entry("*magenta", ColorCode.BRIGHT_MAGENTA),
+                    Map.entry("*cyan", ColorCode.BRIGHT_CYAN),
+                    Map.entry("*white", ColorCode.BRIGHT_WHITE)
+            ));
     /**
      * A static, unmodifiable map that associates lowercase background color names (keys)
      * with their corresponding BackgroundCode enum constants (values).
      */
-    static final Map<String, BackgroundCode> BACKGROUND_CODES = Map.ofEntries(
+    static final StyleContext BACKGROUND_CODES = StyleContext.from(Map.ofEntries(
             // Standard Background Colors
             Map.entry("bg_black", BackgroundCode.BLACK),
             Map.entry("bg_red", BackgroundCode.RED),
@@ -63,12 +65,12 @@ public final class StyleMaps {
             Map.entry("*bg_magenta", BackgroundCode.BRIGHT_MAGENTA),
             Map.entry("*bg_cyan", BackgroundCode.BRIGHT_CYAN),
             Map.entry("*bg_white", BackgroundCode.BRIGHT_WHITE)
-    );
+    ));
     /**
      * A static, unmodifiable map that associates lowercase style names (keys)
      * with their corresponding StyleCode enum constants (values).
      */
-    static final Map<String, StyleCode> STYLE_CODES = Map.ofEntries(
+    static final StyleContext STYLE_CODES = StyleContext.from(Map.ofEntries(
             Map.entry("bold", StyleCode.BOLD),
             Map.entry("dim", StyleCode.DIM),
             Map.entry("italic", StyleCode.ITALIC),
@@ -78,35 +80,43 @@ public final class StyleMaps {
             Map.entry("/", StyleCode.RESET),
             Map.entry("dbl_ul", StyleCode.DOUBLE_UNDERLINE),
             Map.entry("strike", StyleCode.STRIKETHROUGH)
-    );
+    ));
 
     static final Map<String, AnsiCode> CUSTOM_STYLE_CODES = new ConcurrentHashMap<>();
 
-    private StyleMaps() {
+
+    //Local -> Global -> Predefined
+    public static AnsiCode get(String s, StyleContext ctx){
+        AnsiCode code = ctx.get(s);
+
+        if (code != null){
+            return code;
+        }
+
+        code = PredefinedStyleContext.CUSTOM_STYLE_CODES.get(s);
+        if (code != null) {
+            return code;
+        }
+
+        code = PredefinedStyleContext.COLOR_CODES.get(s);
+        if (code != null) {
+            return code;
+        }
+
+        code = PredefinedStyleContext.BACKGROUND_CODES.get(s);
+        if (code != null) {
+            return code;
+        }
+
+        code = PredefinedStyleContext.STYLE_CODES.get(s);
+        return code;
+    }
+
+    private PredefinedStyleContext() {
         throw new AssertionError();
     }
 
-    static Optional<AnsiCode> findStyle(String s){
-        AnsiCode code = CUSTOM_STYLE_CODES.get(s);
-        if (code != null) {
-            return Optional.of(code);
-        }
-
-        code = COLOR_CODES.get(s);
-        if (code != null) {
-            return Optional.of(code);
-        }
-
-        code = BACKGROUND_CODES.get(s);
-        if (code != null) {
-            return Optional.of(code);
-        }
-
-        code = STYLE_CODES.get(s);
-        if (code != null) {
-            return Optional.of(code);
-        }
-
-        return Optional.empty();
+    static Optional<AnsiCode> findStyle(String s, StyleContext ctx){
+        return Optional.ofNullable(get(s, ctx));
     }
 }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/Tokenizer.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/core/parser/Tokenizer.java
@@ -2,6 +2,7 @@ package io.github.kusoroadeolu.clique.core.parser;
 
 import io.github.kusoroadeolu.clique.core.documentation.InternalApi;
 import io.github.kusoroadeolu.clique.core.exceptions.UnidentifiedStyleException;
+import io.github.kusoroadeolu.clique.parser.StyleContext;
 import io.github.kusoroadeolu.clique.spi.AnsiCode;
 
 import java.util.ArrayList;
@@ -23,18 +24,20 @@ public final class Tokenizer {
     private static final char ESCAPE_SEQUENCE = '\\';
     private Tokenizer(){}
 
-    public static ParseResult tokenize(String input, String delimiter, boolean enableStrictParsing){
-        return tokenize(input, delimiter, enableStrictParsing, new ArrayList<>());
+    public static ParseResult tokenize(String input, String delimiter, boolean enableStrictParsing) {
+        return tokenize(input, delimiter, enableStrictParsing, StyleContext.builder().build());
     }
 
-    /**
-     * Extracts valid tokens and form tags from the given string
-     *
-     * @param input The string to parse
-     * @return A parse result containing the form tags and the parser tokens
-     *
-     */
-    public static ParseResult tokenize(String input, String delimiter, boolean enableStrictParsing, List<ParseToken> tokens) {
+
+        /**
+         * Extracts valid tokens and form tags from the given string
+         *
+         * @param input The string to parse
+         * @return A parse result containing the form tags and the parser tokens
+         *
+         */
+    public static ParseResult tokenize(String input, String delimiter, boolean enableStrictParsing, StyleContext context) {
+        List<ParseToken> tokens = new ArrayList<>();
         final String delimiterPattern = Pattern.quote(delimiter);
 
         if (input == null || input.isEmpty()) return new ParseResult(List.of());
@@ -59,7 +62,7 @@ public final class Tokenizer {
 
                 if (fsDepth == 1 && fcDepth == 1){ //Only if we dont have nested tags, with both open and closed tags
                     final String fullTag = input.substring(idx, i + 1); //Parse the extracted input, something like this[tag]
-                    final List<AnsiCode> validStyles = getValidStyles(fullTag, delimiterPattern, enableStrictParsing);
+                    final List<AnsiCode> validStyles = getValidStyles(fullTag, delimiterPattern, context ,enableStrictParsing);
                     if (!validStyles.isEmpty()) {
                         tokens.add(new ParseToken(idx, i, validStyles));
                     }
@@ -87,7 +90,7 @@ public final class Tokenizer {
 
     //Check if there are valid styles in the extracted string
     //ESP -> Enable strict parsing
-    private static List<AnsiCode> getValidStyles(String tag, String delimiterPattern, boolean esp) {
+    private static List<AnsiCode> getValidStyles(String tag, String delimiterPattern, StyleContext context ,boolean esp) {
         if (tag.length() <= 2) return List.of();  //Check if the extracted string is just empty braces, or a malformed tag
         tag = removeForms(tag); //Clean the string
 
@@ -95,41 +98,22 @@ public final class Tokenizer {
         final List<AnsiCode> validStyles = new ArrayList<>();
         for (String s : styles) {
             s = s.toLowerCase(Locale.ROOT).trim();
-            addValidStyles(s, validStyles, esp);
+            addValidStyles(s, validStyles, context ,esp);
         }
 
         return validStyles;
     }
 
 
-    //Replaces forms with empty strings
     private static String removeForms(String s) {
         return s.substring(1, s.length() - 1);
     }
 
     // A helper method that checks if each map contains a key of the given string
-    private static void addValidStyles(String s, List<AnsiCode> validStyles, boolean enableStrictParsing) {
-        AnsiCode code = StyleMaps.CUSTOM_STYLE_CODES.get(s);
-        if (code != null) {
-            validStyles.add(code);
-            return;
-        }
-
-        code = StyleMaps.COLOR_CODES.get(s);
-        if (code != null) {
-            validStyles.add(code);
-            return;
-        }
-
-        code = StyleMaps.BACKGROUND_CODES.get(s);
-        if (code != null) {
-            validStyles.add(code);
-            return;
-        }
-
-        code = StyleMaps.STYLE_CODES.get(s);
-        if (code != null) {
-            validStyles.add(code);
+    private static void addValidStyles(String s, List<AnsiCode> list, StyleContext context, boolean enableStrictParsing) {
+        AnsiCode code = PredefinedStyleContext.get(s, context);
+        if (code != null){
+            list.add(code);
             return;
         }
 

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/MarkupParser.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/MarkupParser.java
@@ -62,7 +62,8 @@ public record MarkupParser(ParserConfiguration parserConfiguration) {
         return Tokenizer.tokenize(
                 input,
                 parserConfiguration.getDelimiter(),
-                parserConfiguration.getEnableStrictParsing()
+                parserConfiguration.getEnableStrictParsing(),
+                parserConfiguration.getStyleContext()
         );
     }
 }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/MarkupParser.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/MarkupParser.java
@@ -27,7 +27,7 @@ public record MarkupParser(ParserConfiguration parserConfiguration) {
     public String parse(String stringToParse) {
         if (stringToParse == null || stringToParse.isBlank()) return stringToParse;
         final ParseResult result = this.getParseResult(stringToParse);
-        String styled = StyleResolver.resolve(result.tokens(), stringToParse, this.parserConfiguration.getEnableAutoCloseTags());
+        String styled = StyleResolver.resolve(result.tokens(), stringToParse, this.parserConfiguration.getEnableAutoReset());
         return postProcess(styled);
 
     }

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/StyleContext.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/StyleContext.java
@@ -1,0 +1,80 @@
+package io.github.kusoroadeolu.clique.parser;
+
+import io.github.kusoroadeolu.clique.ansi.CompositeColor;
+import io.github.kusoroadeolu.clique.core.documentation.Experimental;
+import io.github.kusoroadeolu.clique.spi.AnsiCode;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@Experimental(since = "4.0.0")
+public final class StyleContext {
+    private final Map<String, AnsiCode> localStyles;
+
+    public static StyleContextBuilder builder(){
+        return new StyleContextBuilder();
+    }
+
+    public static StyleContext from(Map<String, AnsiCode> codes){
+        return new StyleContextBuilder().add(codes).build();
+    }
+
+    public AnsiCode get(String s){
+        return localStyles.get(s);
+    }
+
+
+    StyleContext(StyleContextBuilder builder) {
+        this.localStyles = builder.localStyles;
+    }
+
+    public static class StyleContextBuilder {
+        private final Map<String, AnsiCode> localStyles;
+
+        private StyleContextBuilder() {
+            this.localStyles = new HashMap<>();
+        }
+
+        public StyleContextBuilder add(String markup, AnsiCode code){
+            Objects.requireNonNull(markup, "Markup cannot be null");
+            Objects.requireNonNull(code, "Ansi code cannot be null");
+            localStyles.put(markup, code);
+            return this;
+        }
+
+        public StyleContextBuilder add(String markup, AnsiCode... code){
+            Objects.requireNonNull(markup, "Markup cannot be null");
+            Objects.requireNonNull(code, "Ansi codes cannot be null");
+            localStyles.put(markup, new CompositeColor(code));
+            return this;
+        }
+
+        public StyleContextBuilder add(String markup, Collection<AnsiCode> code){
+            Objects.requireNonNull(markup, "Markup cannot be null");
+            Objects.requireNonNull(code, "Ansi codes cannot be null");
+            localStyles.put(markup, new CompositeColor(code));
+            return this;
+        }
+
+        public StyleContextBuilder add(Map<String, AnsiCode> codes){
+            Objects.requireNonNull(codes, "Map cannot be null");
+            localStyles.putAll(codes);
+            return this;
+        }
+
+        public StyleContextBuilder add(StyleContext context){
+            Objects.requireNonNull(context, "Style context cannot be null");
+            this.localStyles.putAll(context.localStyles);
+            return this;
+        }
+
+
+        public StyleContext build(){
+            return new StyleContext(this);
+        }
+    }
+
+
+}

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/StyleContext.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/parser/StyleContext.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 @Experimental(since = "4.0.0")
 public final class StyleContext {
     private final Map<String, AnsiCode> localStyles;
+    public static final StyleContext NONE = new StyleContext();
 
     public static StyleContextBuilder builder(){
         return new StyleContextBuilder();
@@ -28,6 +29,10 @@ public final class StyleContext {
 
     StyleContext(StyleContextBuilder builder) {
         this.localStyles = builder.localStyles;
+    }
+
+    StyleContext() {
+        this.localStyles = new HashMap<>();
     }
 
     public static class StyleContextBuilder {

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/MarkupParserTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/MarkupParserTest.java
@@ -10,11 +10,9 @@ import io.github.kusoroadeolu.clique.core.exceptions.UnidentifiedStyleException;
 import io.github.kusoroadeolu.clique.core.parser.GlobalStyleRegistry;
 import io.github.kusoroadeolu.clique.core.parser.ParserUtils;
 import io.github.kusoroadeolu.clique.spi.AnsiCode;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -60,7 +58,7 @@ class MarkupParserTest {
     void testAutoCloseTags() {
         ParserConfiguration config = ParserConfiguration
                 .builder()
-                .enableAutoCloseTags()
+                .enableAutoReset()
                 .build();
         MarkupParser parser = new MarkupParser(config);
         String output = parser.parse("[red]Text");
@@ -79,11 +77,18 @@ class MarkupParserTest {
     }
 
     @Test
-    void localStyleShouldResolveBeforeGlobal() {
+    void assert_localStyleResolvesBeforeGlobal() {
         var config = ParserConfiguration.builder().addStyle("mycolor", ColorCode.BLUE).build();
         GlobalStyleRegistry.registerStyle("mycolor", ColorCode.RED);
         String output = Clique.parser(config).parse("[mycolor]Hello"); //Should contain blue instead of red
         assertTrue(output.contains(ColorCode.BLUE.ansiSequence()));
+    }
+
+    @Test
+    void assert_globalStyleResolvesBeforePredefined() {
+        GlobalStyleRegistry.registerStyle("blue", ColorCode.RED);
+        String output = Clique.parser().parse("[blue]Hello"); //Should contain red instead of blue
+        assertTrue(output.contains(ColorCode.RED.ansiSequence()));
     }
 
 

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/MarkupParserTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/MarkupParserTest.java
@@ -3,15 +3,18 @@ package io.github.kusoroadeolu.clique.parser;
 
 import io.github.kusoroadeolu.clique.Clique;
 import io.github.kusoroadeolu.clique.ansi.ColorCode;
+import io.github.kusoroadeolu.clique.ansi.CompositeColor;
 import io.github.kusoroadeolu.clique.ansi.StyleCode;
 import io.github.kusoroadeolu.clique.config.ParserConfiguration;
 import io.github.kusoroadeolu.clique.core.exceptions.UnidentifiedStyleException;
+import io.github.kusoroadeolu.clique.core.parser.GlobalStyleRegistry;
 import io.github.kusoroadeolu.clique.core.parser.ParserUtils;
 import io.github.kusoroadeolu.clique.spi.AnsiCode;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -75,6 +78,14 @@ class MarkupParserTest {
         assertFalse(output.contains("\u001B["));
     }
 
+    @Test
+    void localStyleShouldResolveBeforeGlobal() {
+        var config = ParserConfiguration.builder().addStyle("mycolor", ColorCode.BLUE).build();
+        GlobalStyleRegistry.registerStyle("mycolor", ColorCode.RED);
+        String output = Clique.parser(config).parse("[mycolor]Hello"); //Should contain blue instead of red
+        assertTrue(output.contains(ColorCode.BLUE.ansiSequence()));
+    }
+
 
     //Ansi code methods
     @Test
@@ -100,23 +111,5 @@ class MarkupParserTest {
         var parser = MarkupParser.DEFAULT;
         var string = parser.parse("Hello");
         assertEquals("Hello", parser.getOriginalString(string));
-    }
-}
-
-class CompositeColor implements AnsiCode {
-    private final String compositeCode;
-
-    public CompositeColor(AnsiCode... codes) {
-        StringBuilder sb = new StringBuilder();
-        for (AnsiCode code : codes) {
-            sb.append(code.ansiSequence());
-        }
-        this.compositeCode = sb.toString();
-    }
-
-
-    @Override
-    public String ansiSequence() {
-        return compositeCode;
     }
 }

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/StyleContextTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/parser/StyleContextTest.java
@@ -1,0 +1,47 @@
+package io.github.kusoroadeolu.clique.parser;
+
+import io.github.kusoroadeolu.clique.ansi.ColorCode;
+import io.github.kusoroadeolu.clique.spi.AnsiCode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StyleContextTest {
+
+    @Test
+    void onAdd_assertContainsAnsiCode(){
+       var ctx = StyleContext.builder().add("mycolor", ColorCode.BLUE).build();
+       assertNotNull(ctx.get("mycolor"));
+    }
+
+    @Test
+    void assertDoesNotContainAnsiCode(){
+        var ctx = StyleContext.builder().build();
+        assertNull(ctx.get("mycolor"));
+    }
+
+
+    @Test
+    void assertThrows_onNullMarkupName(){
+        assertThrows(NullPointerException.class, () -> StyleContext.builder().add(null, ColorCode.BLUE).build());
+    }
+
+    @Test
+    void assertThrows_onNullAnsiCode(){
+        assertThrows(NullPointerException.class, () -> StyleContext.builder().add("mycolor", (AnsiCode) null).build());
+    }
+
+    @Test
+    void assertThrows_onNullMapGiven(){
+        assertThrows(NullPointerException.class, () -> StyleContext.builder().add((Map<String, AnsiCode>) null).build());
+    }
+
+    @Test
+    void assertContainsMapContent(){
+        Map<String, AnsiCode> map = Map.of("mycolor", ColorCode.RED);
+        var ctx = StyleContext.from(map);
+        assertNotNull(ctx.get("mycolor"));
+    }
+}

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -1,6 +1,6 @@
 # Parser
 
-Clique's parser allows you to use a simple markup format for styling text instead of verbose `styleBuilder` calls or raw ANSI codes.
+Clique's parser allows you to use a simple markup format for styling text instead of verbose `StyleBuilder` calls or raw ANSI codes.
 
 ## Basic Usage
 ### Parse and Print
@@ -39,7 +39,7 @@ Customize how the parser behaves using `ParserConfiguration`:
 ```java
 ParserConfiguration configuration = ParserConfiguration
         .builder()
-        .enableAutoCloseTags()  // Automatically reset styles between tags to prevent leaking
+        .enableAutoReset()  // Automatically reset styles between tags to prevent leaking
         .delimiter(' ')          // Use space instead of comma as delimiter
         .build();
 
@@ -52,8 +52,65 @@ configuredParser.print("[red bold]Hello[blue] World");
 ### Configuration Options
 
 - **`delimiter(char)`** - Set the delimiter between style attributes (default: `,`)
-- **`enableAutoCloseTags()`** - Automatically resets styles when a new tag is encountered, preventing styles from leaking into subsequent tags
+- **`enableAutoReset()`** - Automatically resets styles when a new tag is encountered, preventing styles from leaking into subsequent tags
 - **`enableStrictParsing()`** - Throw exceptions for unrecognized styles on otherwise valid tags
+- **`addStyle(String, AnsiCode)`** - Register a single custom style for this parser instance
+- **`styleContext(StyleContext)`** - Attach a full `StyleContext` of custom styles to this parser instance
+
+## Local Styles with StyleContext
+
+`StyleContext` lets you register custom styles scoped to a specific parser instance, without touching the global style registry. This is useful when you want custom markup that only applies in a specific context.
+
+```java
+StyleContext ctx = StyleContext.builder()
+        .add("highlight", ColorCode.YELLOW)
+        .add("muted", StyleCode.DIM)
+        .build();
+
+ParserConfiguration config = ParserConfiguration.builder()
+        .styleContext(ctx)
+        .build();
+
+MarkupParser parser = Clique.parser(config);
+parser.print("[highlight]This is highlighted[/] and [muted]this is muted[/]");
+```
+
+You can also register a single style directly on the builder without constructing a full `StyleContext`:
+
+```java
+ParserConfiguration config = ParserConfiguration.builder()
+        .addStyle("highlight", ColorCode.YELLOW)
+        .build();
+```
+
+### Style Resolution Order
+
+When the parser encounters a markup tag, it resolves styles in the following order:
+
+1. **Local styles** — defined via `styleContext()` or `addStyle()` on this parser's configuration
+2. **Global custom styles** — registered via `Clique.registerStyle()`
+3. **Predefined styles** — built-in colors, backgrounds, and text styles
+
+This means local styles always win. If you define `highlight` locally and something with the same name exists globally, the local one takes precedence.
+
+### Combining with Other Configuration
+
+`StyleContext` composes naturally with the rest of `ParserConfiguration`:
+
+```java
+StyleContext ctx = StyleContext.builder()
+        .add("tag", ColorCode.CYAN)
+        .add("warn", ColorCode.YELLOW)
+        .build();
+
+ParserConfiguration config = ParserConfiguration.builder()
+        .styleContext(ctx)
+        .enableAutoReset()
+        .enableStrictParsing()
+        .build();
+
+Clique.parser(config).print("[tag]INFO[/] [warn]Something looks off[/]");
+```
 
 ## Parser Exceptions
 When strict parsing is enabled, the parser throws exceptions for unrecognized styles on valid tags:
@@ -63,9 +120,9 @@ When strict parsing is enabled, the parser throws exceptions for unrecognized st
 Thrown when a valid tag contains a style that doesn't exist:
 ```java
 ParserConfiguration config = ParserConfiguration.builder()
-    .enableStrictParsing()
-    .build();
-    
+        .enableStrictParsing()
+        .build();
+
 MarkupParser parser = Clique.parser(config);
 
 // Throws UnidentifiedStyleException because "bol" is not a recognized style
@@ -87,8 +144,8 @@ Clique.parser().print("\\[red]");
 **Examples:**
 ```java
 "\\[red]"               // Displays: [red]
-"\\[red, bold]"         // Displays: [red, bold]
-"Coords: \\[10, 20]"    // Displays: Coords: [10, 20]
+        "\\[red, bold]"         // Displays: [red, bold]
+        "Coords: \\[10, 20]"    // Displays: Coords: [10, 20]
 ```
 
 ## Markup Syntax Reference


### PR DESCRIPTION
### Added
- `StyleContext` support in `ParserConfiguration` via `styleContext(StyleContext)` and `addStyle(String, AnsiCode)` builder methods, allowing custom styles scoped to a specific parser instance


### Updated
- `enableAutoCloseTags()` renamed to `enableAutoReset()` in `ParserConfiguration` to better reflect its behavior of resetting ANSI codes after each styled segment
