### PR TITLE
feat: add TitleAlign functionality to divider and frame

### DIFF
--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/components/Divider.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/components/Divider.java
@@ -1,6 +1,7 @@
 package io.github.kusoroadeolu.clique.components;
 
 import io.github.kusoroadeolu.clique.configuration.DividerConfiguration;
+import io.github.kusoroadeolu.clique.configuration.TitleAlign;
 import io.github.kusoroadeolu.clique.internal.documentation.Stable;
 import io.github.kusoroadeolu.clique.internal.utils.StringUtils;
 import io.github.kusoroadeolu.clique.style.StyleBuilder;
@@ -25,6 +26,8 @@ public class Divider implements Component {
 	private final int width;
 
 	private String title;
+
+	private TitleAlign titleAlign = TitleAlign.CENTER;
 
 	/**
 	 * Creates a new Divider with the given width and configuration.
@@ -61,7 +64,13 @@ public class Divider implements Component {
 
 
 		int remaining = width - contentLength;
-		int left = remaining / 2;
+
+		int left = switch (titleAlign) {
+			case LEFT -> 1;
+			case RIGHT -> remaining - 1;
+			case CENTER -> remaining / 2;
+		};
+
 		int right = remaining - left;
 
         var dividerColor = configuration.getDividerColor();
@@ -83,15 +92,24 @@ public class Divider implements Component {
 	 * @return this divider instance
 	 */
 	public Divider title(String title) {
-        Objects.requireNonNull(title, "Divider title cannot be null");
-        String visible = configuration.getParser().getOriginalString(title);
-        if (visible.length() + 2 >= width) {
-            throw new IllegalArgumentException(
-                    "Title's visible length must be less than divider width."
-            );
-        }
-        this.title = title;
-        return this;
+       return title(title, TitleAlign.CENTER);
+	}
+
+	public Divider title(String title, TitleAlign titleAlign) {
+		Objects.requireNonNull(title, "Divider title cannot be null");
+		Objects.requireNonNull(titleAlign, "Title align cannot be null");
+
+		String visible = configuration.getParser().getOriginalString(title);
+
+		if (visible.length() + 2 >= width) {
+			throw new IllegalArgumentException(
+					"Title's visible length must be less than divider width."
+			);
+		}
+
+		this.title = title;
+		this.titleAlign = titleAlign;
+		return this;
 	}
 
 	@Override

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/components/Frame.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/components/Frame.java
@@ -110,7 +110,7 @@ public class Frame implements Component {
     /**
      * Sets the frame title with center alignment.
      *
-     * <p>Equivalent to {@code title(title, FrameAlign.CENTER)}.
+     * <p>Equivalent to {@code title(title, TitleAlign.CENTER)}.
      *
      * @param title the title text; must not be {@code null}
      * @return this frame, for chaining

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/components/Frame.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/components/Frame.java
@@ -3,6 +3,7 @@ package io.github.kusoroadeolu.clique.components;
 import io.github.kusoroadeolu.clique.configuration.BoxType;
 import io.github.kusoroadeolu.clique.configuration.FrameAlign;
 import io.github.kusoroadeolu.clique.configuration.FrameConfiguration;
+import io.github.kusoroadeolu.clique.configuration.TitleAlign;
 import io.github.kusoroadeolu.clique.internal.BorderChars;
 import io.github.kusoroadeolu.clique.internal.Cell;
 import io.github.kusoroadeolu.clique.internal.FrameNode;
@@ -43,7 +44,7 @@ public class Frame implements Component {
     private final FrameConfiguration configuration;
     private final BoxType type;
     private String title;
-    private FrameAlign titleAlign;
+    private TitleAlign titleAlign;
     private int width;
     private final BorderChars borderChars;
     private static final int NO_WIDTH_SET = 0;
@@ -54,7 +55,7 @@ public class Frame implements Component {
         this.configuration = Objects.requireNonNull(configuration, "Configuration cannot be null");
         this.type = Objects.requireNonNull(type, "Frame type cannot be null");
         this.title = EMPTY;
-        this.titleAlign = FrameAlign.CENTER;
+        this.titleAlign = TitleAlign.CENTER;
         this.width = NO_WIDTH_SET;
         borderChars = BorderChars.from(type);
         this.colorBorders(borderChars);
@@ -84,12 +85,26 @@ public class Frame implements Component {
      * @throws NullPointerException if {@code title} or {@code titleAlign} is {@code null}
      * @throws InvalidDimensionException if the title is wider than the resolved frame width, thrown at render time via {@link #get()}
      */
-    public Frame title(String title, FrameAlign titleAlign) {
+    public Frame title(String title, TitleAlign titleAlign) {
         Objects.requireNonNull(title, "Title cannot be null");
         Objects.requireNonNull(titleAlign, NULL_FRAME_ALIGN);
         this.title = title;
         this.titleAlign = titleAlign;
         return this;
+    }
+
+    /**
+     * @deprecated use {@link #title(String, TitleAlign)} instead
+     */
+    @Deprecated
+    public Frame title(String title, FrameAlign titleAlign) {
+        Objects.requireNonNull(titleAlign, NULL_FRAME_ALIGN);
+
+        return title(title, switch (titleAlign) {
+            case LEFT -> TitleAlign.LEFT;
+            case RIGHT -> TitleAlign.RIGHT;
+            case CENTER -> TitleAlign.CENTER;
+        });
     }
 
     /**
@@ -102,7 +117,7 @@ public class Frame implements Component {
      * @throws NullPointerException if {@code title} is {@code null}
      */
     public Frame title(String title) {
-        return title(title, FrameAlign.CENTER);
+        return title(title, TitleAlign.CENTER);
     }
 
     /**
@@ -324,7 +339,7 @@ public class Frame implements Component {
                 .orElse(ZERO);
     }
 
-    static int findTitleBlockOffset(int givenWidth, int titleWidth, FrameAlign align) {
+    static int findTitleBlockOffset(int givenWidth, int titleWidth, TitleAlign align) {
         return switch (align) {
             case LEFT -> 1;
             case RIGHT -> (givenWidth - titleWidth) - 1; //20 - 20 - 1, Gives  -1, By adding 1 to the title width, we get

--- a/clique-core/src/main/java/io/github/kusoroadeolu/clique/configuration/TitleAlign.java
+++ b/clique-core/src/main/java/io/github/kusoroadeolu/clique/configuration/TitleAlign.java
@@ -1,0 +1,7 @@
+package io.github.kusoroadeolu.clique.configuration;
+
+public enum TitleAlign {
+    LEFT,
+    RIGHT,
+    CENTER
+}

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/components/DividerTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/components/DividerTest.java
@@ -2,6 +2,7 @@ package io.github.kusoroadeolu.clique.components;
 
 import io.github.kusoroadeolu.clique.Clique;
 import io.github.kusoroadeolu.clique.configuration.DividerConfiguration;
+import io.github.kusoroadeolu.clique.configuration.TitleAlign;
 import io.github.kusoroadeolu.clique.internal.exception.UnidentifiedStyleException;
 import io.github.kusoroadeolu.clique.internal.utils.AnsiDetector;
 import io.github.kusoroadeolu.clique.parser.MarkupParser;
@@ -137,6 +138,36 @@ class DividerTest {
 			assertTrue(output.contains(ColorCode.GREEN.ansiSequence() + "Clique rocks" + StyleCode.RESET));
 			assertTrue(output.startsWith(ColorCode.RED.ansiSequence()));
 			assertTrue(output.endsWith(StyleCode.RESET.ansiSequence()));
+		}
+
+		@Test
+		void leftAlignedTitle() {
+			var divider = Clique.divider(20).title("Clique rocks", TitleAlign.LEFT);
+			var output = MarkupParser.DEFAULT.getOriginalString(divider.get());
+			assertEquals(20, output.length());
+			assertEquals("─ Clique rocks ─────", output);
+		}
+
+		@Test
+		void centerAlignedTitle() {
+			var divider = Clique.divider(20).title("Clique rocks", TitleAlign.CENTER);
+			var output = MarkupParser.DEFAULT.getOriginalString(divider.get());
+			assertEquals(20, output.length());
+			assertEquals("─── Clique rocks ───", output);
+		}
+
+		@Test
+		void rightAlignedTitle() {
+			var divider = Clique.divider(20).title("Clique rocks", TitleAlign.RIGHT);
+			var output = MarkupParser.DEFAULT.getOriginalString(divider.get());
+			assertEquals(20, output.length());
+			assertEquals("───── Clique rocks ─", output);
+		}
+
+		@Test
+		void nullTitleAlign() {
+			var divider = Clique.divider(20);
+			assertThrows(NullPointerException.class, () -> divider.title("Clique rocks", null));
 		}
 	}
 }

--- a/clique-core/src/test/java/io/github/kusoroadeolu/clique/components/FrameTest.java
+++ b/clique-core/src/test/java/io/github/kusoroadeolu/clique/components/FrameTest.java
@@ -1,6 +1,7 @@
 package io.github.kusoroadeolu.clique.components;
 
 import io.github.kusoroadeolu.clique.configuration.FrameAlign;
+import io.github.kusoroadeolu.clique.configuration.TitleAlign;
 import io.github.kusoroadeolu.clique.internal.exception.InvalidDimensionException;
 import io.github.kusoroadeolu.clique.internal.utils.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -98,6 +99,51 @@ class FrameTest {
         assertEquals(ls[0].length(), ls[ls.length - 1].length());
     }
 
+    @Test
+    void titleAlignPositionsTitleCorrectly() {
+        String left = stripAnsi(
+                new Frame()
+                        .width(20)
+                        .title("Title", TitleAlign.LEFT)
+                        .nest("content")
+                        .get()
+        );
+
+        String center = stripAnsi(
+                new Frame()
+                        .width(20)
+                        .title("Title", TitleAlign.CENTER)
+                        .nest("content")
+                        .get()
+        );
+
+        String right = stripAnsi(
+                new Frame()
+                        .width(20)
+                        .title("Title", TitleAlign.RIGHT)
+                        .nest("content")
+                        .get()
+        );
+
+        String leftTop = lines(left)[0];
+        String centerTop = lines(center)[0];
+        String rightTop = lines(right)[0];
+
+        assertTrue(leftTop.indexOf(" Title ") < centerTop.indexOf(" Title "));
+        assertTrue(centerTop.indexOf(" Title ") < rightTop.indexOf(" Title "));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void deprecatedFrameAlignTitleStillWorks() {
+        Frame frame = new Frame();
+        assertDoesNotThrow(() ->
+                frame.nest("Hello")
+                        .title("Title", FrameAlign.LEFT)
+                        .get()
+        );
+    }
+
     // -------------------------
     // Nested component tests
     // -------------------------
@@ -186,28 +232,28 @@ class FrameTest {
     @Test
     void test_autosizeFrame_whenTitleWidth_greaterThanFrameContent_andAlignedLeft(){
         Frame frame = new Frame();
-        frame.nest("Hello").title(" ".repeat(20), FrameAlign.LEFT);
+        frame.nest("Hello").title(" ".repeat(20), TitleAlign.LEFT);
         assertDoesNotThrow(frame::get);
     }
 
     @Test
     void test_autosizeFrame_whenTitleWidth_greaterThanFrameContent_andAlignedRight(){
         Frame frame = new Frame();
-        frame.nest("Hello").title(" ".repeat(20), FrameAlign.RIGHT);
+        frame.nest("Hello").title(" ".repeat(20), TitleAlign.RIGHT);
         assertDoesNotThrow(frame::get);
     }
 
     @Test
     void test_autosizeFrame_whenTitleWidth_greaterThanFrameContent_andAlignedCenter(){
         Frame frame = new Frame();
-        frame.nest("Hello").title(" ".repeat(20), FrameAlign.CENTER);
+        frame.nest("Hello").title(" ".repeat(20), TitleAlign.CENTER);
         assertDoesNotThrow(frame::get);
     }
 
     @Test
     void test_givenWidthFrame_whenTitleWidth_equalToContent_andAlignedLeft(){
         Frame frame = new Frame();
-        frame.nest("Hello").title(" ".repeat(5), FrameAlign.LEFT).width(9);
+        frame.nest("Hello").title(" ".repeat(5), TitleAlign.LEFT).width(9);
         assertDoesNotThrow(frame::get);
     }
 }


### PR DESCRIPTION
## Summary

Adds `TitleAlign` support for divider and frame titles as described in #93.

### Changes

* Added a new `TitleAlign` enum with `LEFT`, `CENTER`, and `RIGHT` options.
* Added `Divider#title(String, TitleAlign)` to support configurable divider title alignment.
* Kept `Divider#title(String)` centered by default for backwards compatibility.
* Added `Frame#title(String, TitleAlign)` and updated frame title alignment to use `TitleAlign`.
* Deprecated `Frame#title(String, FrameAlign)` while keeping it functional for backwards compatibility.
* Added and updated tests covering left, center, and right title alignment.

## Testing

* Added tests for `Divider` title alignment.
* Added tests for `Frame` title alignment and deprecated API compatibility.
* Full Maven test suite passes successfully.

Closes #93
